### PR TITLE
Adds support for "fyne release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 - Add support for "fyne release" #3
 - Add support for creating packaged .tar.gz bundles on freebsd #6
-- Update fyne cli to v1.4.2-0.20201122132119-67b762f56dc0 fyne-io#1527
+- Update fyne cli to v1.4.2-0.20201125075943-97ad77d2abe0 (fyne-io#1538 fyne-io#1527)
 
 ## [0.9.0]
 - Releaseing under project namespace with previous 2.2.1 becoming 0.9.0 in fyne-io namespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - Fyne.io fyne-cross
 
+## Unreleased
+- Add support for "fyne release" #3
+- Add support for creating packaged .tar.gz bundles on freebsd #6
+- Update fyne cli to v1.4.2-0.20201122132119-67b762f56dc0 fyne-io#1527
+
 ## [0.9.0]
 - Releaseing under project namespace with previous 2.2.1 becoming 0.9.0 in fyne-io namespace
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Supported targets are:
   -  android
   -  ios
 
-> Note: iOS compilation is supported only on darwin hosts. See [fyne README mobile](https://github.com/fyne-io/fyne/blob/v1.2.4/README-mobile.md#ios) for pre-requisites.
+> Note: 
+> - iOS compilation is supported only on darwin hosts. See [fyne pre-requisites](https://developer.fyne.io/started/#prerequisites) for details.
+> - windows packaging for public distrubution (release mode) is supported only on windows hosts.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supported targets are:
 
 > Note: 
 > - iOS compilation is supported only on darwin hosts. See [fyne pre-requisites](https://developer.fyne.io/started/#prerequisites) for details.
+> - macOS packaging for public distrubution (release mode) is supported only on darwin hosts.
 > - windows packaging for public distrubution (release mode) is supported only on windows hosts.
 
 ## Requirements

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the fyne-cross docker images will be documented in this f
 Release cycle won't follow the fyne-cross one, so the images will be tagged using the label
 year.month.day along with the latest one.
 
+# Release 20.11.25
+- Update fyne cli to v1.4.2-0.20201125075943-97ad77d2abe0 fyne-io#1538
+
 # Release 20.11.23
 - Update fyne cli to v1.4.2-0.20201122132119-67b762f56dc0 fyne-io#1527
 

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the fyne-cross docker images will be documented in this f
 Release cycle won't follow the fyne-cross one, so the images will be tagged using the label
 year.month.day along with the latest one.
 
+# Release 20.11.28
+- Update fyne cli to v1.4.2-0.20201127180716-f9f91c194737 fyne-io#1609
+
 # Release 20.11.25
 - Update fyne cli to v1.4.2-0.20201125075943-97ad77d2abe0 fyne-io#1538
 

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the fyne-cross docker images will be documented in this f
 Release cycle won't follow the fyne-cross one, so the images will be tagged using the label
 year.month.day along with the latest one.
 
+# Release 20.11.04
+- fyne cli updated to v1.4.0
+
 # Archive
 
 These releases occurred in the original namspace, lucor/fyne-cross

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the fyne-cross docker images will be documented in this f
 Release cycle won't follow the fyne-cross one, so the images will be tagged using the label
 year.month.day along with the latest one.
 
+# Release 20.11.23
+- Update fyne cli to v1.4.2-0.20201122132119-67b762f56dc0 fyne-io#1527
+
 # Release 20.11.04
 - fyne cli updated to v1.4.0
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 # docker cross 1.13.15
 ARG DOCKER_CROSS_VERSION=sha256:11a04661d910f74c419623ef7880024694f9151c17578af15e86c45cdf6c8588
 # fyne stable branch
-ARG FYNE_VERSION=97ad77d2abe02267a7da7e32e3685d77d5b084b7
+ARG FYNE_VERSION=f9f91c1947370189c73384fb12ee799b1cf68638
 
 # Build the fyne command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS fyne

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 # docker cross 1.13.15
 ARG DOCKER_CROSS_VERSION=sha256:11a04661d910f74c419623ef7880024694f9151c17578af15e86c45cdf6c8588
 # fyne stable branch
-ARG FYNE_VERSION=67b762f56dc0bf54ffeb93c42b5b5c40d3a9b244
+ARG FYNE_VERSION=97ad77d2abe02267a7da7e32e3685d77d5b084b7
 
 # Build the fyne command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS fyne

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 # docker cross 1.13.15
 ARG DOCKER_CROSS_VERSION=sha256:11a04661d910f74c419623ef7880024694f9151c17578af15e86c45cdf6c8588
 # fyne stable branch
-ARG FYNE_VERSION=v1.4.0
+ARG FYNE_VERSION=67b762f56dc0bf54ffeb93c42b5b5c40d3a9b244
 
 # Build the fyne command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS fyne

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 # docker cross 1.13.15
 ARG DOCKER_CROSS_VERSION=sha256:11a04661d910f74c419623ef7880024694f9151c17578af15e86c45cdf6c8588
 # fyne stable branch
-ARG FYNE_VERSION=v1.3.3
+ARG FYNE_VERSION=v1.4.0
 
 # Build the fyne command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS fyne

--- a/internal/command/android.go
+++ b/internal/command/android.go
@@ -43,6 +43,8 @@ func (cmd *Android) Parse(args []string) error {
 	}
 
 	flagSet.StringVar(&flags.Keystore, "keystore", "", "The location of .keystore file containing signing information")
+	flagSet.StringVar(&flags.KeystorePass, "keystore-pass", "", "Password for the .keystore file")
+	flagSet.StringVar(&flags.KeyPass, "key-pass", "", "Password for the signer's private key, which is needed if the private key is password-protected")
 
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)
@@ -165,7 +167,9 @@ Options:
 type androidFlags struct {
 	*CommonFlags
 
-	Keystore string //Keystore represents the location of .keystore file containing signing information
+	Keystore     string //Keystore represents the location of .keystore file containing signing information
+	KeystorePass string //Password for the .keystore file
+	KeyPass      string //Password for the signer's private key, which is needed if the private key is password-protected
 }
 
 // makeAndroidContext returns the command context for an android target
@@ -184,6 +188,8 @@ func makeAndroidContext(flags *androidFlags, args []string) (Context, error) {
 	ctx.ID = androidOS
 
 	ctx.Keystore = flags.Keystore
+	ctx.KeystorePass = flags.KeystorePass
+	ctx.KeyPass = flags.KeyPass
 
 	// set context based on command-line flags
 	if flags.DockerImage == "" {

--- a/internal/command/android.go
+++ b/internal/command/android.go
@@ -42,6 +42,8 @@ func (cmd *Android) Parse(args []string) error {
 		CommonFlags: commonFlags,
 	}
 
+	flagSet.StringVar(&flags.Keystore, "keystore", "", "The location of .keystore file containing signing information")
+
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)
 
@@ -95,7 +97,11 @@ func (cmd *Android) Run() error {
 		return err
 	}
 
-	err = fynePackage(ctx)
+	if ctx.Release {
+		err = fyneRelease(ctx)
+	} else {
+		err = fynePackage(ctx)
+	}
 	if err != nil {
 		return fmt.Errorf("could not package the Fyne app: %v", err)
 	}
@@ -142,6 +148,8 @@ Options:
 // androidFlags defines the command-line flags for the android command
 type androidFlags struct {
 	*CommonFlags
+
+	Keystore string //Keystore represents the location of .keystore file containing signing information
 }
 
 // makeAndroidContext returns the command context for an android target
@@ -158,6 +166,8 @@ func makeAndroidContext(flags *androidFlags, args []string) (Context, error) {
 
 	ctx.OS = androidOS
 	ctx.ID = androidOS
+
+	ctx.Keystore = flags.Keystore
 
 	// set context based on command-line flags
 	if flags.DockerImage == "" {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -106,11 +106,20 @@ func printUsage(template string, data interface{}) {
 }
 
 // checkFyneBinHost checks if the fyne cli tool is installed on the host
-func checkFyneBinHost() (string, error) {
+func checkFyneBinHost(ctx Context) (string, error) {
 	fyne, err := exec.LookPath("fyne")
 	if err != nil {
 		return "", fmt.Errorf("missed requirement: fyne. To install: `go get fyne.io/fyne/cmd/fyne` and add $GOPATH/bin to $PATH")
 	}
+
+	if ctx.Debug {
+		out, err := exec.Command(fyne, "version").Output()
+		if err != nil {
+			return fyne, fmt.Errorf("could not get fyne cli %s version: %v", fyne, err)
+		}
+		log.Debugf("%s", out)
+	}
+
 	return fyne, nil
 }
 
@@ -118,7 +127,7 @@ func checkFyneBinHost() (string, error) {
 // Note: at the moment this is used only for the ios builds
 func fynePackageHost(ctx Context) error {
 
-	fyne, err := checkFyneBinHost()
+	fyne, err := checkFyneBinHost(ctx)
 	if err != nil {
 		return err
 	}
@@ -160,7 +169,7 @@ func fynePackageHost(ctx Context) error {
 // Note: at the moment this is used only for the ios and windows builds
 func fyneReleaseHost(ctx Context) error {
 
-	fyne, err := checkFyneBinHost()
+	fyne, err := checkFyneBinHost(ctx)
 	if err != nil {
 		return err
 	}
@@ -182,6 +191,8 @@ func fyneReleaseHost(ctx Context) error {
 	}
 
 	switch ctx.OS {
+	case darwinOS:
+		args = append(args, "-category", ctx.Category)
 	case iosOS:
 		args = append(args, "-certificate", ctx.Certificate)
 		args = append(args, "-profile", ctx.Profile)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/icon"
 	"github.com/fyne-io/fyne-cross/internal/log"
@@ -132,6 +133,12 @@ func fynePackageHost(ctx Context) error {
 		"-appVersion", ctx.AppVersion,
 	}
 
+	// add tags to command, if any
+	tags := ctx.Tags
+	if len(tags) > 0 {
+		args = append(args, "-tags", fmt.Sprintf("'%s'", strings.Join(tags, ",")))
+	}
+
 	// run the command from the host
 	fyneCmd := exec.Command(fyne, args...)
 	fyneCmd.Dir = ctx.WorkDirHost()
@@ -166,6 +173,12 @@ func fyneReleaseHost(ctx Context) error {
 		"-appID", ctx.AppID,
 		"-appBuild", ctx.AppBuild,
 		"-appVersion", ctx.AppVersion,
+	}
+
+	// add tags to command, if any
+	tags := ctx.Tags
+	if len(tags) > 0 {
+		args = append(args, "-tags", fmt.Sprintf("'%s'", strings.Join(tags, ",")))
 	}
 
 	switch ctx.OS {

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -57,6 +57,7 @@ type Context struct {
 	Pull         bool   // Pull if true attempts to pull a newer version of the docker image
 
 	// Release context
+	Category     string //Category represents the category of the app for store listing [macOS]
 	Certificate  string //Certificate represents the name of the certificate to sign the build [iOS, Windows]
 	Developer    string //Developer represents the developer identity for your Microsoft store account [Windows]
 	Keystore     string //Keystore represents the location of .keystore file containing signing information [Android]

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -57,11 +57,13 @@ type Context struct {
 	Pull         bool   // Pull if true attempts to pull a newer version of the docker image
 
 	// Release context
-	Certificate string //Certificate represents the name of the certificate to sign the build [iOS, Windows]
-	Developer   string //Developer represents the developer identity for your Microsoft store account [Windows]
-	Keystore    string //Keystore represents the location of .keystore file containing signing information [Android]
-	Password    string //Password represents the password for the certificate used to sign the build [Windows]
-	Profile     string //Profile represents the name of the provisioning profile for this release build [iOS]
+	Certificate  string //Certificate represents the name of the certificate to sign the build [iOS, Windows]
+	Developer    string //Developer represents the developer identity for your Microsoft store account [Windows]
+	Keystore     string //Keystore represents the location of .keystore file containing signing information [Android]
+	KeystorePass string //KeystorePass represents the password for the .keystore file [Android]
+	KeyPass      string //KeyPass represents the assword for the signer's private key, which is needed if the private key is password-protected [Android]
+	Password     string //Password represents the password for the certificate used to sign the build [Windows]
+	Profile      string //Profile represents the name of the provisioning profile for this release build [iOS]
 }
 
 // String implements the Stringer interface

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -2,9 +2,11 @@ package command
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/log"
@@ -41,6 +43,7 @@ type Context struct {
 	OS           string   // OS defines the target OS
 	Tags         []string // Tags defines the tags to use
 
+	AppBuild     string // Build number
 	AppID        string // AppID is the appID to use for distribution
 	CacheEnabled bool   // CacheEnabled if true enable go build cache
 	DockerImage  string // DockerImage defines the docker image used to build
@@ -87,6 +90,12 @@ func makeDefaultContext(flags *CommonFlags, args []string) (Context, error) {
 		Volume:       vol,
 		Pull:         flags.Pull,
 	}
+
+	if flags.AppBuild <= 0 {
+		return ctx, errors.New("build number should be greater than 0")
+	}
+
+	ctx.AppBuild = strconv.Itoa(flags.AppBuild)
 
 	ctx.Package, err = packageFromArgs(args, vol)
 	if err != nil {

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -45,6 +45,7 @@ type Context struct {
 
 	AppBuild     string // Build number
 	AppID        string // AppID is the appID to use for distribution
+	AppVersion   string // AppVersion is the version number in the form x, x.y or x.y.z semantic version
 	CacheEnabled bool   // CacheEnabled if true enable go build cache
 	DockerImage  string // DockerImage defines the docker image used to build
 	Icon         string // Icon is the optional icon in png format to use for distribution
@@ -80,6 +81,7 @@ func makeDefaultContext(flags *CommonFlags, args []string) (Context, error) {
 	// set context based on command-line flags
 	ctx := Context{
 		AppID:        flags.AppID,
+		AppVersion:   flags.AppVersion,
 		CacheEnabled: !flags.NoCache,
 		DockerImage:  flags.DockerImage,
 		Env:          flags.Env,

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -57,7 +57,11 @@ type Context struct {
 	Pull         bool   // Pull if true attempts to pull a newer version of the docker image
 
 	// Release context
+	Certificate string //Certificate represents the name of the certificate to sign the build [iOS, Windows]
+	Developer   string //Developer represents the developer identity for your Microsoft store account [Windows]
 	Keystore    string //Keystore represents the location of .keystore file containing signing information [Android]
+	Password    string //Password represents the password for the certificate used to sign the build [Windows]
+	Profile     string //Profile represents the name of the provisioning profile for this release build [iOS]
 }
 
 // String implements the Stringer interface

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -50,6 +50,7 @@ type Context struct {
 	Icon         string // Icon is the optional icon in png format to use for distribution
 	Output       string // Output is the name output
 	Package      string // Package is the package to build named by the import path as per 'go build'
+	Release      bool   // Enable release mode. If true, prepares an application for public distribution
 	StripDebug   bool   // StripDebug if true, strips binary output
 	Debug        bool   // Debug if true enable debug log
 	Pull         bool   // Pull if true attempts to pull a newer version of the docker image
@@ -89,6 +90,7 @@ func makeDefaultContext(flags *CommonFlags, args []string) (Context, error) {
 		Debug:        flags.Debug,
 		Volume:       vol,
 		Pull:         flags.Pull,
+		Release:      flags.Release,
 	}
 
 	if flags.AppBuild <= 0 {

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -55,6 +55,9 @@ type Context struct {
 	StripDebug   bool   // StripDebug if true, strips binary output
 	Debug        bool   // Debug if true enable debug log
 	Pull         bool   // Pull if true attempts to pull a newer version of the docker image
+
+	// Release context
+	Keystore    string //Keystore represents the location of .keystore file containing signing information [Android]
 }
 
 // String implements the Stringer interface

--- a/internal/command/context_test.go
+++ b/internal/command/context_test.go
@@ -27,9 +27,12 @@ func Test_makeDefaultContext(t *testing.T) {
 		{
 			name: "default",
 			args: args{
-				flags: &CommonFlags{},
+				flags: &CommonFlags{
+					AppBuild: 1,
+				},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,
@@ -41,10 +44,12 @@ func Test_makeDefaultContext(t *testing.T) {
 			name: "custom env",
 			args: args{
 				flags: &CommonFlags{
-					Env: envFlag{"TEST=true"},
+					AppBuild: 1,
+					Env:      envFlag{"TEST=true"},
 				},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,
@@ -57,10 +62,12 @@ func Test_makeDefaultContext(t *testing.T) {
 			name: "custom ldflags",
 			args: args{
 				flags: &CommonFlags{
-					Ldflags: "-X main.version=1.2.3",
+					AppBuild: 1,
+					Ldflags:  "-X main.version=1.2.3",
 				},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,
@@ -72,9 +79,12 @@ func Test_makeDefaultContext(t *testing.T) {
 		{
 			name: "package default",
 			args: args{
-				flags: &CommonFlags{},
+				flags: &CommonFlags{
+					AppBuild: 1,
+				},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,
@@ -85,10 +95,13 @@ func Test_makeDefaultContext(t *testing.T) {
 		{
 			name: "package dot",
 			args: args{
-				flags: &CommonFlags{},
-				args:  []string{"."},
+				flags: &CommonFlags{
+					AppBuild: 1,
+				},
+				args: []string{"."},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,
@@ -99,10 +112,13 @@ func Test_makeDefaultContext(t *testing.T) {
 		{
 			name: "package relative",
 			args: args{
-				flags: &CommonFlags{},
-				args:  []string{"./cmd/command"},
+				flags: &CommonFlags{
+					AppBuild: 1,
+				},
+				args: []string{"./cmd/command"},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,
@@ -113,10 +129,13 @@ func Test_makeDefaultContext(t *testing.T) {
 		{
 			name: "package absolute",
 			args: args{
-				flags: &CommonFlags{},
-				args:  []string{volume.JoinPathHost(vol.WorkDirHost(), "cmd/command")},
+				flags: &CommonFlags{
+					AppBuild: 1,
+				},
+				args: []string{volume.JoinPathHost(vol.WorkDirHost(), "cmd/command")},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,
@@ -127,8 +146,10 @@ func Test_makeDefaultContext(t *testing.T) {
 		{
 			name: "package absolute outside work dir",
 			args: args{
-				flags: &CommonFlags{},
-				args:  []string{os.TempDir()},
+				flags: &CommonFlags{
+					AppBuild: 1,
+				},
+				args: []string{os.TempDir()},
 			},
 			wantErr: true,
 		},
@@ -136,10 +157,12 @@ func Test_makeDefaultContext(t *testing.T) {
 			name: "custom tags",
 			args: args{
 				flags: &CommonFlags{
-					Tags: tagsFlag{"hints", "gles"},
+					AppBuild: 1,
+					Tags:     tagsFlag{"hints", "gles"},
 				},
 			},
 			want: Context{
+				AppBuild:     "1",
 				Volume:       vol,
 				CacheEnabled: true,
 				StripDebug:   true,

--- a/internal/command/context_test.go
+++ b/internal/command/context_test.go
@@ -199,6 +199,26 @@ func Test_makeDefaultContext(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "app version",
+			args: args{
+				flags: &CommonFlags{
+					AppBuild:   1,
+					AppVersion: "1.0",
+					Release:    true,
+				},
+			},
+			want: Context{
+				AppBuild:     "1",
+				AppVersion:   "1.0",
+				Volume:       vol,
+				CacheEnabled: true,
+				StripDebug:   true,
+				Package:      ".",
+				Release:      true,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/command/context_test.go
+++ b/internal/command/context_test.go
@@ -171,6 +171,34 @@ func Test_makeDefaultContext(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "invalid app build",
+			args: args{
+				flags: &CommonFlags{
+					AppBuild: 0,
+				},
+			},
+			want:    Context{},
+			wantErr: true,
+		},
+		{
+			name: "release mode enabled",
+			args: args{
+				flags: &CommonFlags{
+					AppBuild: 1,
+					Release:  true,
+				},
+			},
+			want: Context{
+				AppBuild:     "1",
+				Volume:       vol,
+				CacheEnabled: true,
+				StripDebug:   true,
+				Package:      ".",
+				Release:      true,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -191,6 +191,7 @@ func fynePackage(ctx Context) error {
 		"-icon", volume.JoinPathContainer(ctx.TmpDirContainer(), ctx.ID, icon.Default),
 		"-appID", ctx.AppID,
 		"-appBuild", ctx.AppBuild,
+		"-appVersion", ctx.AppVersion,
 	}
 
 	// Enable release mode, if specified

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -194,6 +194,12 @@ func fynePackage(ctx Context) error {
 		"-appVersion", ctx.AppVersion,
 	}
 
+	// add tags to command, if any
+	tags := ctx.Tags
+	if len(tags) > 0 {
+		args = append(args, "-tags", fmt.Sprintf("'%s'", strings.Join(tags, ",")))
+	}
+
 	// Enable release mode, if specified
 	if ctx.Release {
 		args = append(args, "-release")
@@ -217,6 +223,7 @@ func fynePackage(ctx Context) error {
 		CacheEnabled: ctx.CacheEnabled,
 		WorkDir:      workDir,
 		Debug:        ctx.Debug,
+		Env:          ctx.Env,
 	}
 
 	err := Run(ctx.DockerImage, ctx.Volume, runOpts, args)
@@ -247,6 +254,12 @@ func fyneRelease(ctx Context) error {
 		"-appVersion", ctx.AppVersion,
 	}
 
+	// add tags to command, if any
+	tags := ctx.Tags
+	if len(tags) > 0 {
+		args = append(args, "-tags", fmt.Sprintf("'%s'", strings.Join(tags, ",")))
+	}
+
 	// workDir default value
 	workDir := ctx.WorkDirContainer()
 
@@ -269,6 +282,7 @@ func fyneRelease(ctx Context) error {
 		CacheEnabled: ctx.CacheEnabled,
 		WorkDir:      workDir,
 		Debug:        ctx.Debug,
+		Env:          ctx.Env,
 	}
 
 	err := Run(ctx.DockerImage, ctx.Volume, runOpts, args)

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -254,6 +254,8 @@ func fyneRelease(ctx Context) error {
 	case androidOS:
 		workDir = volume.JoinPathContainer(workDir, ctx.Package)
 		args = append(args, "-keyStore", ctx.Keystore)
+		args = append(args, "-keyStorePass", ctx.KeystorePass)
+		args = append(args, "-keyPass", ctx.KeyPass)
 	case iosOS:
 		args = append(args, "-certificate", ctx.Certificate)
 		args = append(args, "-profile", ctx.Profile)

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -193,6 +193,11 @@ func fynePackage(ctx Context) error {
 		"-appBuild", ctx.AppBuild,
 	}
 
+	// Enable release mode, if specified
+	if ctx.Release {
+		args = append(args, "-release")
+	}
+
 	// workDir default value
 	workDir := ctx.WorkDirContainer()
 

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -202,7 +202,7 @@ func fynePackage(ctx Context) error {
 	// workDir default value
 	workDir := ctx.WorkDirContainer()
 
-	if ctx.OS == androidOS || ctx.OS == iosOS {
+	if ctx.OS == androidOS {
 		workDir = volume.JoinPathContainer(workDir, ctx.Package)
 	}
 
@@ -244,7 +244,6 @@ func fyneRelease(ctx Context) error {
 		"-appID", ctx.AppID,
 		"-appBuild", ctx.AppBuild,
 		"-appVersion", ctx.AppVersion,
-		"-release",
 	}
 
 	// workDir default value
@@ -254,6 +253,13 @@ func fyneRelease(ctx Context) error {
 	case androidOS:
 		workDir = volume.JoinPathContainer(workDir, ctx.Package)
 		args = append(args, "-keyStore", ctx.Keystore)
+	case iosOS:
+		args = append(args, "-certificate", ctx.Certificate)
+		args = append(args, "-profile", ctx.Profile)
+	case windowsOS:
+		args = append(args, "-certificate", ctx.Certificate)
+		args = append(args, "-developer", ctx.Developer)
+		args = append(args, "-password", ctx.Password)
 	}
 
 	runOpts := Options{

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -190,6 +190,7 @@ func fynePackage(ctx Context) error {
 		"-name", ctx.Output,
 		"-icon", volume.JoinPathContainer(ctx.TmpDirContainer(), ctx.ID, icon.Default),
 		"-appID", ctx.AppID,
+		"-appBuild", ctx.AppBuild,
 	}
 
 	// workDir default value

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -20,6 +20,8 @@ type CommonFlags struct {
 	AppBuild int
 	// AppID represents the application ID used for distribution
 	AppID string
+	// AppVersion represents the version number in the form x, x.y or x.y.z semantic version
+	AppVersion string
 	// CacheDir is the directory used to share/cache sources and dependencies.
 	// Default to system cache directory (i.e. $HOME/.cache/fyne-cross)
 	CacheDir string
@@ -74,6 +76,7 @@ func newCommonFlags() (*CommonFlags, error) {
 	flags := &CommonFlags{}
 	flagSet.IntVar(&flags.AppBuild, "app-build", 1, "Build number, should be greater than 0 and incremented for each build")
 	flagSet.StringVar(&flags.AppID, "app-id", output, "Application ID used for distribution")
+	flagSet.StringVar(&flags.AppVersion, "app-version", "1.0", "Version number in the form x, x.y or x.y.z semantic version")
 	flagSet.StringVar(&flags.CacheDir, "cache", cacheDir, "Directory used to share/cache sources and dependencies")
 	flagSet.BoolVar(&flags.NoCache, "no-cache", false, "Do not use the go build cache")
 	flagSet.Var(&flags.Env, "env", "List of additional env variables specified as KEY=VALUE and separated by comma")

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -39,6 +39,8 @@ type CommonFlags struct {
 	NoStripDebug bool
 	// Output represents the named output file
 	Output string
+	// Release represents if the package should be prepared for release (disable debug etc)
+	Release bool
 	// RootDir represents the project root directory
 	RootDir string
 	// Silent enables the silent mode
@@ -81,6 +83,7 @@ func newCommonFlags() (*CommonFlags, error) {
 	flagSet.Var(&flags.Tags, "tags", "List of additional build tags separated by comma")
 	flagSet.BoolVar(&flags.NoStripDebug, "no-strip-debug", false, "Do not strip debug information from binaries")
 	flagSet.StringVar(&flags.Output, "output", output, "Named output file")
+	flagSet.BoolVar(&flags.Release, "release", false, "Release mode. Prepares the application for public distribution")
 	flagSet.StringVar(&flags.RootDir, "dir", rootDir, "Fyne app root directory")
 	flagSet.BoolVar(&flags.Silent, "silent", false, "Silent mode")
 	flagSet.BoolVar(&flags.Debug, "debug", false, "Debug mode")

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -15,6 +15,9 @@ var flagSet = flag.NewFlagSet("fyne-cross", flag.ExitOnError)
 
 // CommonFlags holds the flags shared between all commands
 type CommonFlags struct {
+	// AppBuild represents the build number, should be greater than 0 and
+	// incremented for each build
+	AppBuild int
 	// AppID represents the application ID used for distribution
 	AppID string
 	// CacheDir is the directory used to share/cache sources and dependencies.
@@ -67,6 +70,7 @@ func newCommonFlags() (*CommonFlags, error) {
 	}
 
 	flags := &CommonFlags{}
+	flagSet.IntVar(&flags.AppBuild, "app-build", 1, "Build number, should be greater than 0 and incremented for each build")
 	flagSet.StringVar(&flags.AppID, "app-id", output, "Application ID used for distribution")
 	flagSet.StringVar(&flags.CacheDir, "cache", cacheDir, "Directory used to share/cache sources and dependencies")
 	flagSet.BoolVar(&flags.NoCache, "no-cache", false, "Do not use the go build cache")

--- a/internal/command/windows_test.go
+++ b/internal/command/windows_test.go
@@ -25,12 +25,15 @@ func Test_makeWindowsContext(t *testing.T) {
 			name: "default",
 			args: args{
 				flags: &windowsFlags{
-					CommonFlags: &CommonFlags{},
-					TargetArch:  &targetArchFlag{"amd64"},
+					CommonFlags: &CommonFlags{
+						AppBuild: 1,
+					},
+					TargetArch: &targetArchFlag{"amd64"},
 				},
 			},
 			want: []Context{
 				{
+					AppBuild:     "1",
 					Volume:       vol,
 					CacheEnabled: true,
 					StripDebug:   true,
@@ -48,13 +51,16 @@ func Test_makeWindowsContext(t *testing.T) {
 			name: "console",
 			args: args{
 				flags: &windowsFlags{
-					CommonFlags: &CommonFlags{},
-					TargetArch:  &targetArchFlag{"386"},
-					Console:     true,
+					CommonFlags: &CommonFlags{
+						AppBuild: 1,
+					},
+					TargetArch: &targetArchFlag{"386"},
+					Console:    true,
 				},
 			},
 			want: []Context{
 				{
+					AppBuild:     "1",
 					Volume:       vol,
 					CacheEnabled: true,
 					StripDebug:   true,
@@ -72,13 +78,15 @@ func Test_makeWindowsContext(t *testing.T) {
 			args: args{
 				flags: &windowsFlags{
 					CommonFlags: &CommonFlags{
-						Ldflags: "-X main.version=1.2.3",
+						AppBuild: 1,
+						Ldflags:  "-X main.version=1.2.3",
 					},
 					TargetArch: &targetArchFlag{"amd64"},
 				},
 			},
 			want: []Context{
 				{
+					AppBuild:     "1",
 					Volume:       vol,
 					CacheEnabled: true,
 					StripDebug:   true,
@@ -97,6 +105,7 @@ func Test_makeWindowsContext(t *testing.T) {
 			args: args{
 				flags: &windowsFlags{
 					CommonFlags: &CommonFlags{
+						AppBuild:    1,
 						DockerImage: "test",
 					},
 					TargetArch: &targetArchFlag{"amd64"},
@@ -104,6 +113,7 @@ func Test_makeWindowsContext(t *testing.T) {
 			},
 			want: []Context{
 				{
+					AppBuild:     "1",
 					Volume:       vol,
 					CacheEnabled: true,
 					StripDebug:   true,


### PR DESCRIPTION
This PR adds support for "fyne release"

- [x] Update fyne cli to v1.4.2-0.20201127180716-f9f91c194737 fyne-io/fyne#1609 fyne-io/fyne#1527 fyne-io/fyne#1538 (Release 20.11.28)
- [x] Add support to: AppBuild, Release and AppVersion flags
- [x] Add support to "fyne release" for android os
- [x] Add support to "fyne release" for windows os
- [x] Add support to "fyne release" for ios os
- [x] Add support to "fyne release" for macOS os

> Note: since "release" for windows, ios and macOS requires native tools, it is supported only on the relative hosts via the fyne-cli tool.

Fixes #1 