### PR TITLE
Fix env flag validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for creating packaged .tar.gz bundles on freebsd #6
 - Update fyne cli to v1.4.2-0.20201125075943-97ad77d2abe0 (fyne-io#1538 fyne-io#1527)
 - Deprecate `output` flag in favour of `name`
+- Fix env flag validation #14
 
 ## [0.9.0]
 - Releaseing under project namespace with previous 2.2.1 becoming 0.9.0 in fyne-io namespace

--- a/internal/command/context_test.go
+++ b/internal/command/context_test.go
@@ -59,6 +59,24 @@ func Test_makeDefaultContext(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "custom env containg =",
+			args: args{
+				flags: &CommonFlags{
+					AppBuild: 1,
+					Env:      envFlag{"GOFLAGS=-mod=vendor"},
+				},
+			},
+			want: Context{
+				AppBuild:     "1",
+				Volume:       vol,
+				CacheEnabled: true,
+				StripDebug:   true,
+				Package:      ".",
+				Env:          []string{"GOFLAGS=-mod=vendor"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "custom ldflags",
 			args: args{
 				flags: &CommonFlags{

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -123,14 +123,12 @@ func (ef *envFlag) Set(value string) error {
 	}
 
 	for _, v := range strings.Split(value, ",") {
-
 		*ef = append(*ef, v)
 	}
 
 	// validate env vars
 	for _, v := range *ef {
-		parts := strings.Split(v, "=")
-		if len(parts) != 2 {
+		if !strings.Contains(v, "=") {
 			return errors.New("env var must defined as KEY=VALUE or KEY=")
 		}
 	}

--- a/internal/command/flag_test.go
+++ b/internal/command/flag_test.go
@@ -1,0 +1,54 @@
+package command
+
+import "testing"
+
+func Test_envFlag_Set(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name:    "simple env var",
+			value:   "CGO_ENABLED=1",
+			wantLen: 1,
+			wantErr: false,
+		},
+		{
+			name:    "env var without value",
+			value:   "KEY=",
+			wantLen: 1,
+			wantErr: false,
+		},
+		{
+			name:    "env var with value containing =",
+			value:   "GOFLAGS=-mod=vendor",
+			wantLen: 1,
+			wantErr: false,
+		},
+		{
+			name:    "two env vars",
+			value:   "GOFLAGS=-mod=vendor,KEY=value",
+			wantLen: 2,
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			value:   "GOFLAGS",
+			wantLen: 1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		ef := &envFlag{}
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ef.Set(tt.value); (err != nil) != tt.wantErr {
+				t.Errorf("envFlag.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if len(*ef) != tt.wantLen {
+				t.Errorf("envFlag len error = %v, wantLen %v", len(*ef), tt.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes the env flag validation that not allow to specify values containg the `=` char like `GOFLAGS=-mod=vendor`

Fixes #5