### PR TITLE
Update Go to v1.14.13 and linux deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update fyne cli to v1.4.2 (fyne-io#1538 fyne-io#1527)
 - Deprecate `output` flag in favour of `name`
 - Fix env flag validation #14
+- Update Go to v1.14.13
 
 ## [0.9.0]
 - Releaseing under project namespace with previous 2.2.1 becoming 0.9.0 in fyne-io namespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Update fyne cli to v1.4.2 (fyne-io#1538 fyne-io#1527)
 - Deprecate `output` flag in favour of `name`
 - Fix env flag validation #14
-- Fix fails to build for linux mobile #19
+- Fix build failure for Linux mobile #19
 - Update Go to v1.14.13
 
 ## [0.9.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update fyne cli to v1.4.2 (fyne-io#1538 fyne-io#1527)
 - Deprecate `output` flag in favour of `name`
 - Fix env flag validation #14
+- Fix fails to build for linux mobile #19
 - Update Go to v1.14.13
 
 ## [0.9.0]

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -7,7 +7,7 @@ year.month.day along with the latest one.
 
 # Release 20.12.13
 - Update Go to v1.14.13
-- Fix fails to build for linux mobile #19
+- Fix build failure for Linux mobile #19
 
 # Release 20.12.10
 - Update fyne cli to v1.4.2

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -7,6 +7,7 @@ year.month.day along with the latest one.
 
 # Release 20.12.13
 - Update Go to v1.14.13
+- Fix fails to build for linux mobile #19
 
 # Release 20.12.10
 - Update fyne cli to v1.4.2

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to the fyne-cross docker images will be documented in this f
 Release cycle won't follow the fyne-cross one, so the images will be tagged using the label
 year.month.day along with the latest one.
 
+# Release 20.12.13
+- Update Go to v1.14.13
+
 # Release 20.12.10
 - Update fyne cli to v1.4.2
+> Note: this version is the last that provides Go v1.13.x
 
 # Release 20.12.05
 - Update fyne cli to v1.4.2-0.20201204171445-8f33697cf611

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -14,11 +14,15 @@ WORKDIR /app
 COPY . .
 RUN GO111MODULE=on go build -o /go/bin/gowindres -ldflags="-w -s" ./internal/cmd/gowindres
 
+FROM golang:1.14.13-buster AS golang
+
 # Build the fyne-cross base image
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION}
 
 COPY --from=fyne /go/bin/fyne /usr/local/bin
 COPY --from=gowindres /go/bin/gowindres /usr/local/bin
+RUN rm -rf /usr/local/go
+COPY --from=golang /usr/local/go /usr/local/go
 
 RUN apt-get update -qq \
     && apt-get install -y -q --no-install-recommends \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -qq \
     && apt-get install -y -q --no-install-recommends \
         libgl1-mesa-dev \
         libegl1-mesa-dev \
+        libgles2-mesa-dev \
         xorg-dev \
         gosu \
         zip \

--- a/docker/linux-386/Dockerfile
+++ b/docker/linux-386/Dockerfile
@@ -6,6 +6,7 @@ RUN dpkg --add-architecture i386 \
         gccgo-i686-linux-gnu \
         libgl1-mesa-dev:i386 \
         libegl1-mesa-dev:i386 \
+        libgles2-mesa-dev:i386 \
         libdmx-dev:i386 \
         libfontenc-dev:i386 \
         libfs-dev:i386 \

--- a/docker/linux-arm/Dockerfile
+++ b/docker/linux-arm/Dockerfile
@@ -6,6 +6,7 @@ RUN dpkg --add-architecture armhf \
         gccgo-arm-linux-gnueabihf \
         libgl1-mesa-dev:armhf \
         libegl1-mesa-dev:armhf \
+        libgles2-mesa-dev:armhf \
         libdmx-dev:armhf \
         libfontenc-dev:armhf \
         libfs-dev:armhf \

--- a/docker/linux-arm64/Dockerfile
+++ b/docker/linux-arm64/Dockerfile
@@ -6,6 +6,7 @@ RUN dpkg --add-architecture arm64 \
         gccgo-aarch64-linux-gnu \
         libgl1-mesa-dev:arm64 \
         libegl1-mesa-dev:arm64 \
+        libgles2-mesa-dev:arm64 \
         libdmx-dev:arm64 \
         libfontenc-dev:arm64 \
         libfs-dev:arm64 \


### PR DESCRIPTION
This PR is an attempt to update Go to latest versions.
Additionally fixes #19 

To test:
- ensure to have the latest version from develop: `go get github.com/fyne-io/fyne-cross@develop`
- build the docker images locally: `make build-images`
- clear the go cache: `go cache -clean -modcache`
- build your application with fyne-cross

