### PR TITLE
Fix volume.JoinPathContainer should not depend on the OS 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: "CI"
-on: push
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/internal/volume/volume.go
+++ b/internal/volume/volume.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -103,7 +104,7 @@ func Mount(workDirHost string, cacheDirHost string) (Volume, error) {
 // JoinPathContainer joins any number of path elements into a single path,
 // separating them with the Container OS specific Separator.
 func JoinPathContainer(elem ...string) string {
-	return filepath.Clean(strings.Join(elem, "/"))
+	return path.Clean(strings.Join(elem, "/"))
 }
 
 // JoinPathHost joins any number of path elements into a single path,


### PR DESCRIPTION
This commit fix a regression introduced in d949bc3.
Additionally updates github actions to run on pull requests too
