### PR TITLE
Update Go to v1.14.15 and the fyne cmd command to 2.0.0

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,12 +1,12 @@
 # docker cross 1.13.15
 ARG DOCKER_CROSS_VERSION=sha256:11a04661d910f74c419623ef7880024694f9151c17578af15e86c45cdf6c8588
 # fyne stable branch
-ARG FYNE_VERSION=v1.4.2
+ARG FYNE_VERSION=v2.0.0
 
 # Build the fyne command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS fyne
 ARG FYNE_VERSION
-RUN GO111MODULE=on go get -ldflags="-w -s" -v "fyne.io/fyne/cmd/fyne@${FYNE_VERSION}"
+RUN GO111MODULE=on go get -ldflags="-w -s" -v "fyne.io/fyne/v2/cmd/fyne@${FYNE_VERSION}"
 
 # Build the gowindres command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS gowindres
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY . .
 RUN GO111MODULE=on go build -o /go/bin/gowindres -ldflags="-w -s" ./internal/cmd/gowindres
 
-FROM golang:1.14.13-buster AS golang
+FROM golang:1.14.15-buster AS golang
 
 # Build the fyne-cross base image
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION}


### PR DESCRIPTION
The Go update most notable includes a security fix (CVE-2021-3114) for the `crypto/elliptic` package along with the usual bugfixes. Built the docker image locally and tested a Linux build of [wormhole-gui](https://github.com/Jacalz/wormhole-gui).