### PR TITLE
Fix app-id flag regression

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -137,9 +137,13 @@ func fynePackageHost(ctx Context) error {
 		"-os", ctx.OS,
 		"-name", ctx.Name,
 		"-icon", volume.JoinPathContainer(ctx.TmpDirHost(), ctx.ID, icon.Default),
-		"-appID", ctx.AppID,
 		"-appBuild", ctx.AppBuild,
 		"-appVersion", ctx.AppVersion,
+	}
+
+	// add appID to command, if any
+	if ctx.AppID != "" {
+		args = append(args, "-appID", ctx.AppID)
 	}
 
 	// add tags to command, if any
@@ -179,9 +183,13 @@ func fyneReleaseHost(ctx Context) error {
 		"-os", ctx.OS,
 		"-name", ctx.Name,
 		"-icon", volume.JoinPathContainer(ctx.TmpDirHost(), ctx.ID, icon.Default),
-		"-appID", ctx.AppID,
 		"-appBuild", ctx.AppBuild,
 		"-appVersion", ctx.AppVersion,
+	}
+
+	// add appID to command, if any
+	if ctx.AppID != "" {
+		args = append(args, "-appID", ctx.AppID)
 	}
 
 	// add tags to command, if any

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -189,9 +189,13 @@ func fynePackage(ctx Context) error {
 		"-os", ctx.OS,
 		"-name", ctx.Name,
 		"-icon", volume.JoinPathContainer(ctx.TmpDirContainer(), ctx.ID, icon.Default),
-		"-appID", ctx.AppID,
 		"-appBuild", ctx.AppBuild,
 		"-appVersion", ctx.AppVersion,
+	}
+
+	// add appID to command, if any
+	if ctx.AppID != "" {
+		args = append(args, "-appID", ctx.AppID)
 	}
 
 	// add tags to command, if any
@@ -249,9 +253,13 @@ func fyneRelease(ctx Context) error {
 		"-os", ctx.OS,
 		"-name", ctx.Name,
 		"-icon", volume.JoinPathContainer(ctx.TmpDirContainer(), ctx.ID, icon.Default),
-		"-appID", ctx.AppID,
 		"-appBuild", ctx.AppBuild,
 		"-appVersion", ctx.AppVersion,
+	}
+
+	// add appID to command, if any
+	if ctx.AppID != "" {
+		args = append(args, "-appID", ctx.AppID)
 	}
 
 	// add tags to command, if any


### PR DESCRIPTION
This PR update the package and release command to not use the appID value if empty.
This applies only for target OSes that does not require it.
