### PR TITLE
Darwin image build: add support for SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,15 @@ fyne-cross linux
 fyne-cross linux -output bugs ./cmd/bugs
 ```
 
-## <a name="build_darwin_image"></a>Build the docker image for OSX/Darwin/Apple builds
+## <a name="build_darwin_image"></a>Build the docker image for OSX/Darwin/Apple cross-compiling
 The docker image for darwin is not provided via docker hub and need to build manually since it depends on the OSX SDK.
 
 **[Please ensure you have read and understood the Xcode license
    terms before continuing.](https://www.apple.com/legal/sla/docs/xcode.pdf)**
 
 To build the image:
-1. [Download Command Line Tools for Xcode](https://developer.apple.com/download/more) >= 12.4
-2. Run: `fyne-cross darwin-image --xcode-path /path/to/Command_Line_Tools_for_Xcode_<version>.dmg`
+1. [Download Command Line Tools for Xcode](https://developer.apple.com/download/more) 12.5 (macOS SDK 11.3)
+2. Run: `fyne-cross darwin-image --xcode-path /path/to/Command_Line_Tools_for_Xcode_12.5.dmg`
 
 The command above will:
 - install the dependencies required by [osxcross](https://github.com/tpoechtrager/osxcross) to package the macOS SDK and compile the macOS cross toolchain.
@@ -131,6 +131,16 @@ The command above will:
 - build the `fyneio/fyne-cross:<ver>-darwin` image that will be used by fyne-cross
 
 > NOTE: the creation of the image may take several minutes and may require more than 25 GB of free disk space.
+
+### [EXPERIMENTAL] Build using a different SDK version
+
+If for any reason a different SDK version is required, it can be specified using the `--sdk-version` flag.
+
+Example:
+
+`fyne-cross darwin-image --sdk-version 11.1 --xcode-path /path/to/Command_Line_Tools_for_Xcode_12.4.dmg`
+
+> Note: this feature is marked as EXPERIMENTAL. The `darwin-image` has been configured and tested against the SDK version reported above. It *may* work with different versions. If not, please feel free to open an [issue](https://github.com/fyne-io/fyne-cross/issues) with the details.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The docker image for darwin is not provided via docker hub and need to build man
    terms before continuing.](https://www.apple.com/legal/sla/docs/xcode.pdf)**
 
 To build the image:
-1. [Download Command Line Tools for Xcode](https://developer.apple.com/download/more) 12.5 (macOS SDK 11.3)
+1. [Download Command Line Tools for Xcode](https://developer.apple.com/download/more) >= 12.4 (macOS SDK 11.x)
 2. Run: `fyne-cross darwin-image --xcode-path /path/to/Command_Line_Tools_for_Xcode_12.5.dmg`
 
 The command above will:
@@ -134,13 +134,13 @@ The command above will:
 
 ### [EXPERIMENTAL] Build using a different SDK version
 
-If for any reason a different SDK version is required, it can be specified using the `--sdk-version` flag.
+By default fyne-cross will attempt to auto-detect the latest version of SDK provided by the Xcode package. If for any reason a different SDK version is required, it can be specified using the `--sdk-version` flag.
 
 Example:
 
 `fyne-cross darwin-image --sdk-version 11.1 --xcode-path /path/to/Command_Line_Tools_for_Xcode_12.4.dmg`
 
-> Note: this feature is marked as EXPERIMENTAL. The `darwin-image` has been configured and tested against the SDK version reported above. It *may* work with different versions. If not, please feel free to open an [issue](https://github.com/fyne-io/fyne-cross/issues) with the details.
+> Note: this feature is marked as EXPERIMENTAL
 
 ## Contribute
 

--- a/docker/darwin/Dockerfile
+++ b/docker/darwin/Dockerfile
@@ -29,9 +29,13 @@ RUN curl -L https://github.com/tpoechtrager/osxcross/archive/${OSX_CROSS_COMMIT}
 
 RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
-RUN mv MacOSX*.tar.bz2 tarballs && echo "Available SDKs:" && ls -1 tarballs
-
 ARG SDK_VERSION
+RUN echo "Available SDKs:" && ls -1 MacOSX*.tar.bz2 && \
+    if [ -z "$SDK_VERSION" ] ;\
+     then ls -1 MacOSX*.tar.bz2 | sort -Vr | head -1 | xargs -i mv {} tarballs ;\
+     else mv MacOSX*.tar.bz2 tarballs ; \
+    fi
+
 RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh
 
 

--- a/docker/darwin/Dockerfile
+++ b/docker/darwin/Dockerfile
@@ -31,7 +31,8 @@ RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
 RUN mv MacOSX11*.tar.bz2 tarballs
 
-RUN UNATTENDED=yes OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh
+ARG SDK_VERSION
+RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh
 
 
 ## Build darwin-latest image

--- a/docker/darwin/Dockerfile
+++ b/docker/darwin/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -L https://github.com/tpoechtrager/osxcross/archive/${OSX_CROSS_COMMIT}
 
 RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
-RUN mv MacOSX11*.tar.bz2 tarballs
+RUN mv MacOSX*.tar.bz2 tarballs
 
 ARG SDK_VERSION
 RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh

--- a/docker/darwin/Dockerfile
+++ b/docker/darwin/Dockerfile
@@ -1,6 +1,6 @@
 ARG LLVM_VERSION=12
 ARG OSX_VERSION_MIN=10.12
-ARG OSX_CROSS_COMMIT="035cc170338b7b252e3f13b0e3ccbf4411bffc41"
+ARG OSX_CROSS_COMMIT="8a716a43a72dab1db9630d7824ee0af3730cb8f9"
 ARG FYNE_CROSS_VERSION=1.1
 
 ## Build osxcross toolchain
@@ -29,7 +29,7 @@ RUN curl -L https://github.com/tpoechtrager/osxcross/archive/${OSX_CROSS_COMMIT}
 
 RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
-RUN mv MacOSX*.tar.bz2 tarballs
+RUN mv MacOSX*.tar.bz2 tarballs && echo "Available SDKs:" && ls -1 tarballs
 
 ARG SDK_VERSION
 RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh

--- a/internal/command/darwin_image.go
+++ b/internal/command/darwin_image.go
@@ -32,7 +32,7 @@ func (cmd *DarwinImage) Description() string {
 // Parse parses the arguments and set the usage for the command
 func (cmd *DarwinImage) Parse(args []string) error {
 	flagSet.StringVar(&cmd.sdkPath, "xcode-path", "", "Path to the Command Line Tools for Xcode (i.e. /tmp/Command_Line_Tools_for_Xcode_12.4.dmg")
-	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", "11.0", "SDK Version to use")
+	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", "11.1", "SDK Version to use")
 
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)

--- a/internal/command/darwin_image.go
+++ b/internal/command/darwin_image.go
@@ -32,7 +32,7 @@ func (cmd *DarwinImage) Description() string {
 // Parse parses the arguments and set the usage for the command
 func (cmd *DarwinImage) Parse(args []string) error {
 	flagSet.StringVar(&cmd.sdkPath, "xcode-path", "", "Path to the Command Line Tools for Xcode (i.e. /tmp/Command_Line_Tools_for_Xcode_12.4.dmg")
-	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", "11.1", "SDK Version to use")
+	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", "", "SDK Version to use")
 
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)

--- a/internal/command/darwin_image.go
+++ b/internal/command/darwin_image.go
@@ -15,7 +15,8 @@ import (
 
 // DarwinImage builds the darwin docker image
 type DarwinImage struct {
-	sdkPath string
+	sdkPath    string
+	sdkVersion string
 }
 
 // Name returns the one word command name
@@ -31,6 +32,7 @@ func (cmd *DarwinImage) Description() string {
 // Parse parses the arguments and set the usage for the command
 func (cmd *DarwinImage) Parse(args []string) error {
 	flagSet.StringVar(&cmd.sdkPath, "xcode-path", "", "Path to the Command Line Tools for Xcode (i.e. /tmp/Command_Line_Tools_for_Xcode_12.4.dmg")
+	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", "11.0", "SDK Version to use")
 
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)
@@ -85,7 +87,7 @@ func (cmd *DarwinImage) Run() error {
 	log.Info("[i] Building docker image...")
 
 	// run the command from the host
-	dockerCmd := exec.Command("docker", "build", "--pull", "-t", darwinImage, ".")
+	dockerCmd := exec.Command("docker", "build", "--pull", "-e", fmt.Sprintf("SDK_VERSION=%s", cmd.sdkVersion), "-t", darwinImage, ".")
 	dockerCmd.Dir = workDir
 	dockerCmd.Stdout = os.Stdout
 	dockerCmd.Stderr = os.Stderr

--- a/internal/command/darwin_image.go
+++ b/internal/command/darwin_image.go
@@ -13,12 +13,6 @@ import (
 	"github.com/fyne-io/fyne-cross/internal/volume"
 )
 
-const (
-	// macOSSDKDefault is the latest macOS SDK version
-	// known to work with fyne-cross and used as default
-	macOSSDKDefault = "11.3"
-)
-
 // DarwinImage builds the darwin docker image
 type DarwinImage struct {
 	sdkPath    string
@@ -37,8 +31,8 @@ func (cmd *DarwinImage) Description() string {
 
 // Parse parses the arguments and set the usage for the command
 func (cmd *DarwinImage) Parse(args []string) error {
-	flagSet.StringVar(&cmd.sdkPath, "xcode-path", "", "Path to the Command Line Tools for Xcode (i.e. /tmp/Command_Line_Tools_for_Xcode_12.4.dmg")
-	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", macOSSDKDefault, "SDK Version to use")
+	flagSet.StringVar(&cmd.sdkPath, "xcode-path", "", "Path to the Command Line Tools for Xcode (i.e. /tmp/Command_Line_Tools_for_Xcode_12.5.dmg)")
+	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", "", "SDK version to use. Default to automatic detection")
 
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)
@@ -91,7 +85,11 @@ func (cmd *DarwinImage) Run() error {
 	log.Infof("[✓] Dockerfile created")
 
 	log.Info("[i] Building docker image...")
-	log.Info("[i] macOS SDK: ", cmd.sdkVersion)
+	ver := "auto"
+	if cmd.sdkVersion != "" {
+		ver = cmd.sdkVersion
+	}
+	log.Info("[i] macOS SDK: ", ver)
 
 	// run the command from the host
 	dockerCmd := exec.Command("docker", "build", "--pull", "--build-arg", fmt.Sprintf("SDK_VERSION=%s", cmd.sdkVersion), "-t", darwinImage, ".")

--- a/internal/command/darwin_image.go
+++ b/internal/command/darwin_image.go
@@ -13,6 +13,12 @@ import (
 	"github.com/fyne-io/fyne-cross/internal/volume"
 )
 
+const (
+	// macOSSDKDefault is the latest macOS SDK version
+	// known to work with fyne-cross and used as default
+	macOSSDKDefault = "11.3"
+)
+
 // DarwinImage builds the darwin docker image
 type DarwinImage struct {
 	sdkPath    string
@@ -32,7 +38,7 @@ func (cmd *DarwinImage) Description() string {
 // Parse parses the arguments and set the usage for the command
 func (cmd *DarwinImage) Parse(args []string) error {
 	flagSet.StringVar(&cmd.sdkPath, "xcode-path", "", "Path to the Command Line Tools for Xcode (i.e. /tmp/Command_Line_Tools_for_Xcode_12.4.dmg")
-	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", "", "SDK Version to use")
+	flagSet.StringVar(&cmd.sdkVersion, "sdk-version", macOSSDKDefault, "SDK Version to use")
 
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)

--- a/internal/command/darwin_image.go
+++ b/internal/command/darwin_image.go
@@ -85,9 +85,10 @@ func (cmd *DarwinImage) Run() error {
 	log.Infof("[✓] Dockerfile created")
 
 	log.Info("[i] Building docker image...")
+	log.Info("[i] macOS SDK: ", cmd.sdkVersion)
 
 	// run the command from the host
-	dockerCmd := exec.Command("docker", "build", "--pull", "-e", fmt.Sprintf("SDK_VERSION=%s", cmd.sdkVersion), "-t", darwinImage, ".")
+	dockerCmd := exec.Command("docker", "build", "--pull", "--build-arg", fmt.Sprintf("SDK_VERSION=%s", cmd.sdkVersion), "-t", darwinImage, ".")
 	dockerCmd.Dir = workDir
 	dockerCmd.Stdout = os.Stdout
 	dockerCmd.Stderr = os.Stderr

--- a/internal/resource/darwin_dockerfile.go
+++ b/internal/resource/darwin_dockerfile.go
@@ -33,7 +33,7 @@ RUN curl -L https://github.com/tpoechtrager/osxcross/archive/${OSX_CROSS_COMMIT}
 
 RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
-RUN mv MacOSX11*.tar.bz2 tarballs
+RUN mv MacOSX*.tar.bz2 tarballs
 
 ARG SDK_VERSION
 RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh

--- a/internal/resource/darwin_dockerfile.go
+++ b/internal/resource/darwin_dockerfile.go
@@ -33,9 +33,13 @@ RUN curl -L https://github.com/tpoechtrager/osxcross/archive/${OSX_CROSS_COMMIT}
 
 RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
-RUN mv MacOSX*.tar.bz2 tarballs && echo "Available SDKs:" && ls -1 tarballs
-
 ARG SDK_VERSION
+RUN echo "Available SDKs:" && ls -1 MacOSX*.tar.bz2 && \
+    if [ -z "$SDK_VERSION" ] ;\
+     then ls -1 MacOSX*.tar.bz2 | sort -Vr | head -1 | xargs -i mv {} tarballs ;\
+     else mv MacOSX*.tar.bz2 tarballs ; \
+    fi
+
 RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh
 
 

--- a/internal/resource/darwin_dockerfile.go
+++ b/internal/resource/darwin_dockerfile.go
@@ -4,7 +4,7 @@ package resource
 
 const DockerfileDarwin = `ARG LLVM_VERSION=12
 ARG OSX_VERSION_MIN=10.12
-ARG OSX_CROSS_COMMIT="035cc170338b7b252e3f13b0e3ccbf4411bffc41"
+ARG OSX_CROSS_COMMIT="8a716a43a72dab1db9630d7824ee0af3730cb8f9"
 ARG FYNE_CROSS_VERSION=1.1
 
 ## Build osxcross toolchain
@@ -33,7 +33,7 @@ RUN curl -L https://github.com/tpoechtrager/osxcross/archive/${OSX_CROSS_COMMIT}
 
 RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
-RUN mv MacOSX*.tar.bz2 tarballs
+RUN mv MacOSX*.tar.bz2 tarballs && echo "Available SDKs:" && ls -1 tarballs
 
 ARG SDK_VERSION
 RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh

--- a/internal/resource/darwin_dockerfile.go
+++ b/internal/resource/darwin_dockerfile.go
@@ -35,7 +35,8 @@ RUN ./tools/gen_sdk_package_tools_dmg.sh /tmp/command_line_tools_for_xcode.dmg
 
 RUN mv MacOSX11*.tar.bz2 tarballs
 
-RUN UNATTENDED=yes OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh
+ARG SDK_VERSION
+RUN UNATTENDED=yes SDK_VERSION=${SDK_VERSION} OSX_VERSION_MIN=${OSX_VERSION_MIN} ./build.sh
 
 
 ## Build darwin-latest image


### PR DESCRIPTION
This PR add the possibility to select a specified macOS SDK version from the Xcode Command Line package via the `--sdk-version` flag
Default to auto detection mode that will try to use the newest SDK version avaibable in the Xcode package.

The list of macOS SDKs provided by Xcode can be obtained from the [XCode release notes](https://developer.apple.com/documentation/xcode-release-notes/)
