### PR TITLE
Switch to x/sys/execabs for windows security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 )

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,11 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/internal/cmd/gowindres/main.go
+++ b/internal/cmd/gowindres/main.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path"
 	"text/template"
+
+	"golang.org/x/sys/execabs"
 )
 
 var (
@@ -65,7 +66,7 @@ func main() {
 		target = target386
 	}
 
-	cmd := exec.Command(windresBin, "-F", target, "-o", resource, rc)
+	cmd := execabs.Command(windresBin, "-F", target, "-o", resource, rc)
 	cmd.Dir = workDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/icon"
 	"github.com/fyne-io/fyne-cross/internal/log"
 	"github.com/fyne-io/fyne-cross/internal/volume"
+	"golang.org/x/sys/execabs"
 )
 
 // Command wraps the methods for a fyne-cross command
@@ -107,13 +107,13 @@ func printUsage(template string, data interface{}) {
 
 // checkFyneBinHost checks if the fyne cli tool is installed on the host
 func checkFyneBinHost(ctx Context) (string, error) {
-	fyne, err := exec.LookPath("fyne")
+	fyne, err := execabs.LookPath("fyne")
 	if err != nil {
 		return "", fmt.Errorf("missed requirement: fyne. To install: `go get fyne.io/fyne/v2/cmd/fyne` and add $GOPATH/bin to $PATH")
 	}
 
 	if ctx.Debug {
-		out, err := exec.Command(fyne, "version").Output()
+		out, err := execabs.Command(fyne, "version").Output()
 		if err != nil {
 			return fyne, fmt.Errorf("could not get fyne cli %s version: %v", fyne, err)
 		}
@@ -153,7 +153,7 @@ func fynePackageHost(ctx Context) error {
 	}
 
 	// run the command from the host
-	fyneCmd := exec.Command(fyne, args...)
+	fyneCmd := execabs.Command(fyne, args...)
 	fyneCmd.Dir = ctx.WorkDirHost()
 	fyneCmd.Stdout = os.Stdout
 	fyneCmd.Stderr = os.Stderr
@@ -223,7 +223,7 @@ func fyneReleaseHost(ctx Context) error {
 	}
 
 	// run the command from the host
-	fyneCmd := exec.Command(fyne, args...)
+	fyneCmd := execabs.Command(fyne, args...)
 	fyneCmd.Dir = ctx.WorkDirHost()
 	fyneCmd.Stdout = os.Stdout
 	fyneCmd.Stderr = os.Stderr

--- a/internal/command/darwin_image.go
+++ b/internal/command/darwin_image.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/log"
 	"github.com/fyne-io/fyne-cross/internal/resource"
 	"github.com/fyne-io/fyne-cross/internal/volume"
+	"golang.org/x/sys/execabs"
 )
 
 // DarwinImage builds the darwin docker image
@@ -92,7 +92,7 @@ func (cmd *DarwinImage) Run() error {
 	log.Info("[i] macOS SDK: ", ver)
 
 	// run the command from the host
-	dockerCmd := exec.Command("docker", "build", "--pull", "--build-arg", fmt.Sprintf("SDK_VERSION=%s", cmd.sdkVersion), "-t", darwinImage, ".")
+	dockerCmd := execabs.Command("docker", "build", "--pull", "--build-arg", fmt.Sprintf("SDK_VERSION=%s", cmd.sdkVersion), "-t", darwinImage, ".")
 	dockerCmd.Dir = workDir
 	dockerCmd.Stdout = os.Stdout
 	dockerCmd.Stderr = os.Stderr

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"runtime"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/fyne-io/fyne-cross/internal/icon"
 	"github.com/fyne-io/fyne-cross/internal/log"
 	"github.com/fyne-io/fyne-cross/internal/volume"
+	"golang.org/x/sys/execabs"
 )
 
 const (
@@ -23,7 +23,7 @@ const (
 
 // CheckRequirements checks if the docker binary is in PATH
 func CheckRequirements() error {
-	_, err := exec.LookPath("docker")
+	_, err := execabs.LookPath("docker")
 	if err != nil {
 		return fmt.Errorf("missed requirement: docker binary not found in PATH")
 	}
@@ -39,7 +39,7 @@ type Options struct {
 }
 
 // Cmd returns a command to run in a new container for the specified image
-func Cmd(image string, vol volume.Volume, opts Options, cmdArgs []string) *exec.Cmd {
+func Cmd(image string, vol volume.Volume, opts Options, cmdArgs []string) *execabs.Cmd {
 
 	// define workdir
 	w := vol.WorkDirContainer()
@@ -85,7 +85,7 @@ func Cmd(image string, vol volume.Volume, opts Options, cmdArgs []string) *exec.
 	args = append(args, cmdArgs...)
 
 	// run the command inside the container
-	cmd := exec.Command("docker", args...)
+	cmd := execabs.Command("docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -360,7 +360,7 @@ func pullImage(ctx Context) error {
 	buf := bytes.Buffer{}
 
 	// run the command inside the container
-	cmd := exec.Command("docker", "pull", ctx.DockerImage)
+	cmd := execabs.Command("docker", "pull", ctx.DockerImage)
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
 

--- a/internal/command/docker_test.go
+++ b/internal/command/docker_test.go
@@ -3,19 +3,19 @@ package command
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/fyne-io/fyne-cross/internal/volume"
+	"golang.org/x/sys/execabs"
 )
 
 func TestCmd(t *testing.T) {
 
 	expectedCmd := "docker"
-	if lp, err := exec.LookPath(expectedCmd); err == nil {
+	if lp, err := execabs.LookPath(expectedCmd); err == nil {
 		expectedCmd = lp
 	}
 


### PR DESCRIPTION
The os/exec package on Windows will match the behaviour of cmd.exe by considering the local folder as a primary part of the path. This means that a malicious binary with the same name, in the current folder, would be run instead of the expected binary in the system path. Due to the backwards compat being an issue, this could not be fixed within ox/exec before Go v2. See https://blog.golang.org/path-security for more info.

Related to https://github.com/fyne-io/fyne/pull/2344 but not part of the same effort.