### PR TITLE
Update docker images: Go v1.17 and Android builds SDK 30 

### DIFF
--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -3,11 +3,11 @@ FROM fyneio/fyne-cross:${FYNE_CROSS_VERSION}-base
 
 ENV JAVA_HOME /usr/local/android_jdk8
 ENV ANDROID_HOME /usr/local/android_sdk
-ENV ANDROID_SDK_TOOLS_VERSION 4333796
-ENV ANDROID_SDK_TOOLS_SHA256SUM 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
-ENV ANDROID_SDK_BUILD_TOOLS_VERSION 29.0.2
+ENV COMMANDLINETOOLS_VERSION 7583922
+ENV COMMANDLINETOOLS_SHA256SUM 124f2d5115eee365df6cf3228ffbca6fc3911d16f8025bebd5b1c6e2fcfa7faf
+ENV ANDROID_SDK_BUILD_TOOLS_VERSION 30.0.3
 ENV ANDROID_SDK_BUILD_TOOLS_BIN ${ANDROID_HOME}/build-tools/${ANDROID_SDK_BUILD_TOOLS_VERSION}
-ENV ANDROID_SDK_PLATFORM 29
+ENV ANDROID_SDK_PLATFORM 30
 ENV ANDROID_NDK_BIN ${ANDROID_HOME}/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 ENV PATH=${PATH}:${JAVA_HOME}/bin:${ANDROID_NDK_BIN}:${ANDROID_SDK_BUILD_TOOLS_BIN}
@@ -18,14 +18,16 @@ RUN wget -O jdk8.tgz "https://android.googlesource.com/platform/prebuilts/jdk/jd
 	tar zxvf jdk8.tgz -C ${JAVA_HOME}; \
 	rm jdk8.tgz
 
-# Install SDK
-RUN wget -O sdk.zip "https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip"; \
-	echo "${ANDROID_SDK_TOOLS_SHA256SUM} *sdk.zip" | sha256sum -c -; \
-	unzip -d ${ANDROID_HOME} sdk.zip; \
+# Install command line tools
+RUN wget -O sdk.zip "https://dl.google.com/android/repository/commandlinetools-linux-${COMMANDLINETOOLS_VERSION}_latest.zip"; \
+	echo "${COMMANDLINETOOLS_SHA256SUM} *sdk.zip" | sha256sum -c -; \
+	unzip -d /tmp sdk.zip; \
+	mkdir -p ${ANDROID_HOME}/cmdline-tools; \
+	mv /tmp/cmdline-tools ${ANDROID_HOME}/cmdline-tools/latest; \
 	rm sdk.zip;
 
 # Install tools, platforms and ndk
-RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager \
+RUN yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager \
 	"build-tools;${ANDROID_SDK_BUILD_TOOLS_VERSION}" \
 	"ndk-bundle" \
 	"platforms;android-${ANDROID_SDK_PLATFORM}" \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.0
+ARG GO_VERSION=1.16.7
 # fyne stable branch
 ARG FYNE_VERSION=v2.0.4
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.16.7
+ARG GO_VERSION=1.17.0
 # fyne stable branch
 ARG FYNE_VERSION=v2.0.4
 


### PR DESCRIPTION
This PR updates the `android` docker image to use the latest command line tools and updates the Android builds to SDK 30