### PR TITLE
[base-image] Add xz-utils package to support unix packaging

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -23,6 +23,9 @@ above.
 
 Example: `fyneio/fyne-cross:1.1-base-21.03.17`
 
+## Unreleased 
+- Add xz-utils package to support unix packaging fyne-io/fyne#1919
+
 ## Release 21.09.29
 - Update Go to v1.16.8
 - Update fyne CLI to v2.1.0

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update -qq \
         gosu \
         zip \
         unzip \
+        # Switch from gz to xz compression for unix packages fyne-io/fyne#1919
+        xz-utils \
         # fyne deps
         libgl1-mesa-dev \
         libegl1-mesa-dev \


### PR DESCRIPTION
### Description:

Starting from Fyne CLI v2.1.0 the XZ Utils is used to compress unix packages (fyne-io/fyne#1919)
This PR updates the base-image installing the `xz-utils` package

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
