### PR TITLE
Window resource flle need to be placed into the package root to be linked

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [fyne-io, Jacalz]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'unverified'
+assignees: ''
+
+---
+
+<!-- Please search for open issues that relate to the same problem before opening a new one. -->
+
+### Describe the bug:
+<!-- A clear and concise description about the bug. -->
+
+
+### To Reproduce:
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Run the command '...'
+3. See error
+
+### Example code:
+<!-- If applicable, add a link to a repository or a short code snippet to help explain and simplify reproduction of the problem. -->
+<!-- Please write the code inside a code block with go syntax, like this:
+```go
+Write your code here.
+```
+-->
+
+### Device and debug info (please complete the following information):
+
+<summary>Device info</summary>
+
+ - **OS:** <!-- [e.g. Linux, MacOS or iOS] -->
+ - **Version:** <!-- [e.g. 5.10.2, 10.13 High Sierra or 14.2] -->
+ - **Go version:** <!-- [e.g. 1.12.3] -->
+ - **fyne-cross version:** <!-- [e.g. 1.1.1 or git SHA] -->
+ - **Fyne version:** <!-- [e.g. 2.1.0 or git SHA] -->
+
+<details><summary>Debug info</summary><br><pre>
+<!-- To report debug info add here the output of the fyne-cross command having problem executed with the `-no-cache` and `-debug` flags, like this:
+```bash
+fyne-cross linux --debug --no-cache .
+```
+Make sure the output does not contain any sensitive information.
+-->
+</pre></details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Ask a question
+    url: https://fyne.io/support/
+    about: For a toolkit question or help with your code go to our support page

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Please search for open issues that relate to the same feature before opening a new one. -->
+
+### Is your feature request related to a problem? Please describe:
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Is it possible to construct a solution with the existing API?
+<!-- If this is an enhancement have you been able to create something similar,
+or is your desired outcome not possible at this time? -->
+
+### Describe the solution you'd like to see:
+<!-- A clear and concise description of what you want to happen. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- If this is your first pull request for Fyne please read the contributor docs at:
+https://github.com/fyne-io/fyne/wiki/Contributing.
+Be sure that your work is based off `develop` branch. --> 
+
+### Description:
+<!-- A summary of the change included and which issue it addresses.
+Please include any relevant motivation and background. -->
+
+Fixes #(issue)
+
+### Checklist:
+<!-- Please tick these as appropriate using [x] -->
+
+- [ ] Tests included.
+- [ ] Lint and formatter run with no errors.
+- [ ] Tests all pass.
+
+#### Where applicable:
+<!-- Please delete these if not required for this PR -->
+
+- [ ] Public APIs match existing style.
+- [ ] Any breaking changes have a deprecation path or have been discussed.
+- [ ] Updated the vendor folder (using `go mod vendor`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ["1.15.x", "1.14.x"]
+        go-version: ["1.17.x", "1.14.x"]
 
     steps:
     - name: Setup Go environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - Fyne.io fyne-cross
 
-## Unreleased
+## 1.1.2 - 05 Oct 2021
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - Fyne.io fyne-cross
 
+## Unreleased
+
+### Fixed
+
+-  Building for windows fails to add icon #66
+
 ## 1.1.2 - 05 Oct 2021
 
 ### Fixed

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -23,7 +23,7 @@ above.
 
 Example: `fyneio/fyne-cross:1.1-base-21.03.17`
 
-## Unreleased 
+## Release 21.10.05
 - Add xz-utils package to support unix packaging fyne-io/fyne#1919
 
 ## Release 21.09.29

--- a/internal/command/freebsd.go
+++ b/internal/command/freebsd.go
@@ -105,7 +105,7 @@ func (cmd *FreeBSD) Run() error {
 		//
 		log.Info("[i] Packaging app...")
 
-		packageName := fmt.Sprintf("%s.tar.gz", ctx.Name)
+		packageName := fmt.Sprintf("%s.tar.xz", ctx.Name)
 
 		err = prepareIcon(ctx)
 		if err != nil {

--- a/internal/command/linux.go
+++ b/internal/command/linux.go
@@ -106,7 +106,7 @@ func (cmd *Linux) Run() error {
 		//
 		log.Info("[i] Packaging app...")
 
-		packageName := fmt.Sprintf("%s.tar.gz", ctx.Name)
+		packageName := fmt.Sprintf("%s.tar.xz", ctx.Name)
 
 		err = prepareIcon(ctx)
 		if err != nil {


### PR DESCRIPTION
### Description:
The windows resource file (syso) need to be into the package root to be linked automatically by the compiler.

This PR copies the syso file into the package root after it is created.

Fixes #66

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
