### PR TITLE
[base-image] Update Go to v1.17.6

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -23,7 +23,10 @@ above.
 
 Example: `fyneio/fyne-cross:1.1-base-21.03.17`
 
-## 21.12.07
+## Release 22.01.10
+- Update Go to v1.17.6
+
+## Release 21.12.07
 - Update Go to v1.17.4
 - Update fyne CLI to v2.1.2
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.4
+ARG GO_VERSION=1.17.6
 # fyne stable branch
 ARG FYNE_VERSION=v2.1.2
 


### PR DESCRIPTION
### Description:

This PR updates the Go version to v1.17.6 into the docker base image.

The following images have been tagged and released on docker hub for testing:

```
1.1-android-22.01.10
1.1-base-22.01.10
1.1-base-freebsd-22.01.10
1.1-base-llvm-22.01.10
1.1-freebsd-amd64-22.01.10
1.1-freebsd-arm64-22.01.10
1.1-linux-386-22.01.10
1.1-linux-arm-22.01.10
1.1-linux-arm64-22.01.10
1.1-windows-22.01.10
```
