### PR TITLE
Add CI job to build calculator app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         working-directory: fyne-cross
         run: go install
 
+        # attempt to use "go install" but fallback to "go get"
       - name: Install Fyne
         run: |
           go install fyne.io/fyne/v2/cmd/fyne@latest ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,12 @@ jobs:
           - os: darwin
             args: -app-id calc.${GITHUB_SHA}
             host: macos-latest
-          - os: ios
-            args: -app-id calc.${GITHUB_SHA}
-            host: macos-latest
+          
+          ## Currently not easily supported from GitHub actions.
+          ## https://github.com/fyne-io/fyne-cross/pull/104#issuecomment-1099494308
+          # - os: ios
+          #   args: -app-id calc.${GITHUB_SHA}
+          #   host: macos-latest
 
     steps:
       - name: Setup Go environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,18 @@ on: [push, pull_request]
 
 jobs:
   lint:
+    name: Lint
     runs-on: "ubuntu-latest"
     steps:
     - name: Setup Go environment
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: "1.15.x"
+        go-version: "1.18.x"
 
-    - name: Install staticcheck
-      run: go get -v honnef.co/go/tools/cmd/staticcheck
-    - name: Install goimports
-      run: go get -v golang.org/x/tools/cmd/goimports
+    - name: Install linters
+      run: |
+        go install golang.org/x/tools/cmd/goimports@latest
+        go install honnef.co/go/tools/cmd/staticcheck@latest
 
     # Checks-out the repository under $GITHUB_WORKSPACE
     - uses: actions/checkout@v2
@@ -24,18 +25,21 @@ jobs:
     - name: Run goimports
       run: test -z $(find . -name '*.go' -type f | xargs goimports -e -d | tee /dev/stderr)
     - name: Run staticcheck
-      run: staticcheck github.com/fyne-io/fyne-cross/...
+      run: staticcheck ./...
 
   test:
+    name: "Test"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ["1.17.x", "1.14.x"]
+        # use max/min supported Go versions
+        go-version: ["1.18.x", "1.13.x"]
 
     steps:
     - name: Setup Go environment
-      uses: actions/setup-go@v2
+      id: setup-go
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -43,4 +47,75 @@ jobs:
     - uses: actions/checkout@v2
 
     # Run tests
-    - run: go test -race ./...
+    - run: go test -v -cover -race ./...
+
+  build:
+    name: "Build Calculator (${{ matrix.target.os }}, ${{ matrix.go-version }})"
+    runs-on: ${{ matrix.target.host || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # use max/min supported Go versions
+        go-version: ["1.18.x", "1.13.x"]
+        target:
+          - os: linux
+          - os: windows
+            ext: .exe
+          - os: freebsd
+          - os: android
+            args: -app-id calc.${GITHUB_SHA}
+          - os: darwin
+            args: -app-id calc.${GITHUB_SHA}
+            host: macos-latest
+            requires-darwin-image: true
+          - os: ios
+            args: -app-id calc.${GITHUB_SHA}
+            host: macos-latest
+            requires-darwin-image: true
+
+    steps:
+      - name: Setup Go environment
+        id: setup-go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: fyne-cross
+
+      - name: Checkout fyne-io/calculator
+        uses: actions/checkout@v2
+        with:
+          repository: fyne-io/calculator
+          path: calculator
+
+      - name: Cache build artifacts
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/.cache/fyne-cross
+          key: ${{ runner.os }}-build-cache-${{ hashFiles('**/go.sum') }}
+
+      - name: Install Fyne-cross
+        working-directory: fyne-cross
+        run: go install
+
+      - name: Build Darwin image
+        if: ${{ matrix.target.requires-darwin-image }}
+        run: |
+          fyne-cross \
+            darwin-image \
+            -xcode-path $(xcode-select -p)
+            
+      - name: Build
+        working-directory: calculator
+        run: |
+          fyne-cross \
+            ${{ matrix.target.os }} \
+            ${{ matrix.target.args }} \
+            -debug -no-cache \
+            -name calculator${{ matrix.target.ext }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
   build:
     name: "Build Calculator (${{ matrix.target.os }}, ${{ matrix.go-version }})"
     runs-on: ${{ matrix.target.host || 'ubuntu-latest' }}
+    env:
+      GO111MODULE: on
     strategy:
       fail-fast: false
       matrix:
@@ -67,11 +69,9 @@ jobs:
           - os: darwin
             args: -app-id calc.${GITHUB_SHA}
             host: macos-latest
-            requires-darwin-image: true
           - os: ios
             args: -app-id calc.${GITHUB_SHA}
             host: macos-latest
-            requires-darwin-image: true
 
     steps:
       - name: Setup Go environment
@@ -104,12 +104,17 @@ jobs:
         working-directory: fyne-cross
         run: go install
 
-      - name: Build Darwin image
-        if: ${{ matrix.target.requires-darwin-image }}
+      - name: Install Fyne
         run: |
-          fyne-cross \
-            darwin-image \
-            -xcode-path $(xcode-select -p)
+          go install fyne.io/fyne/v2/cmd/fyne@latest ||
+          go get fyne.io/fyne/v2/cmd/fyne@latest
+
+      - name: Install Podman
+        if: ${{ runner.os == 'macos' }}
+        run: |
+          brew install podman
+          podman machine init
+          podman machine start
             
       - name: Build
         working-directory: calculator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # use max/min supported Go versions
-        go-version: ["1.18.x", "1.13.x"]
+        go-version: ["1.18.x", "1.14.x"]
 
     steps:
     - name: Setup Go environment
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         # use max/min supported Go versions
-        go-version: ["1.18.x", "1.13.x"]
+        go-version: ["1.18.x", "1.14.x"]
         target:
           - os: linux
           - os: windows


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

Opening this as a draft PR to get feedback around building for darwin and ios.

This PR adds an additional job to the GitHub Actions CI Workflow that uses fyne-cross to build the Fyne example [calculator project](https://github.com/fyne-io/calculator/). It also makes some small changes to the linting and testing workflow jobs for consistency and compatibility reasons.

The aim of this additional job is to try and catch integration issues that only occur when using fyne-cross to build an actual app. See this bug report for some context: https://github.com/fyne-io/fyne-cross/issues/100

I'm looking for feedback on the following:

* Is there a clean way to build a Fyne app for darwin or ios targets using the macos GitHub Actions runner? According to the docs the macos running comes with [Xcode Command Line Tools](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#tools) installed, but they're not available as a `dmg` to reference using `xcode-path`.
* Should these jobs be run for multiple versions of Go? I don't know what the rationale is behind the current Go versions in the workflow, but I have updated them to be the latest and minimum support versions of Go for the project.
* Do we trust that the Calculator project will not introduce bugs that cause the build to fail unrelated to fyne-cross? We could pin to a specific release of the Calculator if so. 

I'd welcome any and all feedback :)

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
