### PR TITLE
all: update Go to v1.18.8

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -24,9 +24,12 @@ above.
 
 Example: `fyneio/fyne-cross:1.3-base-22.06.23`
 
-## Unreleased
-- Update Go to v1.18.7
+## Release 22.11.01
+- all: update Go to v1.18.8
 - darwin-image: update LLVM and clang to v14
+
+## Release 22.10.18
+- Update Go to v1.18.7
 
 ## Release 22.07.13
 - Update Fyne CLI to v2.2.3

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.7
+ARG GO_VERSION=1.18.8
 # fyne stable branch
 ARG FYNE_VERSION=v2.2.3
 


### PR DESCRIPTION
This PR release the docker base images on docker hub to have them generally available.

#### Release 22.11.01
- all: update Go to v1.18.8 
- darwin-image: update LLVM and clang to v14

#### Images

The following images have been tagged and released on docker hub for testing:
 
```
1.3-android-2022.11.01
1.3-base-2022.11.01
1.3-base-freebsd-2022.11.01
1.3-base-llvm-2022.11.01
1.3-freebsd-amd64-2022.11.01
1.3-freebsd-arm64-2022.11.01
1.3-linux-386-2022.11.01
1.3-linux-arm-2022.11.01
1.3-linux-arm64-2022.11.01
1.3-web-2022.11.01
1.3-windows-2022.11.01
```

> Note: the `latest` tag will tagged and pushed to docker hub as usual once approved 