### PR TITLE
docker: release 22.11.14

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -24,6 +24,9 @@ above.
 
 Example: `fyneio/fyne-cross:1.3-base-22.06.23`
 
+## Unreleased
+- all: update Fyne CLI to v2.2.4
+
 ## Release 22.11.01
 - all: update Go to v1.18.8
 - darwin-image: update LLVM and clang to v14

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -25,6 +25,7 @@ above.
 Example: `fyneio/fyne-cross:1.3-base-22.06.23`
 
 ## Unreleased
+- all: update Go to v1.19.3
 - all: update Fyne CLI to v2.2.4
 
 ## Release 22.11.01

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -24,7 +24,7 @@ above.
 
 Example: `fyneio/fyne-cross:1.3-base-22.06.23`
 
-## Unreleased
+## Release 22.11.14
 - all: update Go to v1.19.3
 - all: update Fyne CLI to v2.2.4
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.8
+ARG GO_VERSION=1.19.3
 # fyne stable branch
 ARG FYNE_VERSION=v2.2.4
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR release the docker base images on docker hub to have them generally available.

#### Release 22.11.14
- all: update Go to v1.19.3
- all: update Fyne CLI to v2.2.4

#### Images
The following images have been tagged and released on docker hub for testing:
```
1.3-android-22.11.14
1.3-base-22.11.14
1.3-base-freebsd-22.11.14
1.3-base-llvm-22.11.14
1.3-freebsd-amd64-22.11.14
1.3-freebsd-arm64
1.3-freebsd-arm64-22.11.14
1.3-linux-386-22.11.14
1.3-linux-arm-22.11.14
1.3-linux-arm64-22.11.14
1.3-web-22.11.14
1.3-windows-22.11.14
```

> Note: the `latest` tag will tagged and pushed to docker hub as usual once approved 