### PR TITLE
Fix path issues for windows

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -102,8 +102,8 @@ func cleanTargetDirs(ctx Context, image containerImage) error {
 
 	dirs := map[string]string{
 		"bin":  volume.JoinPathContainer(ctx.BinDirContainer(), image.ID()),
-		"dist": volume.JoinPathHost(ctx.DistDirContainer(), image.ID()),
-		"temp": volume.JoinPathHost(ctx.TmpDirContainer(), image.ID()),
+		"dist": volume.JoinPathContainer(ctx.DistDirContainer(), image.ID()),
+		"temp": volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID()),
 	}
 
 	log.Infof("[i] Cleaning target directories...")


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
When building, special characters were being created in file paths which were leading to build errors

Fix:
Use `JoinPathContainers` instead of `JoinPathHost` for `dist` and `temp` directiories

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

