### PR TITLE
Normalise executable name for darwin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/urfave/cli/v2 v2.11.1
+	golang.org/x/mod v0.3.0
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 )
 

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,7 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -315,7 +315,7 @@ func calculateExeName(sourceDir, os string) string {
 		}
 	}
 
-	if os == "windows" {
+	if os == windowsOS {
 		exeName = exeName + ".exe"
 	}
 

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"github.com/fyne-io/fyne-cross/internal/icon"
 	"github.com/fyne-io/fyne-cross/internal/log"
 	"github.com/fyne-io/fyne-cross/internal/volume"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 )
 
 const (
@@ -202,7 +205,12 @@ func goBuild(ctx Context, image containerImage) error {
 	}
 
 	// set output folder to fyne-cross/bin/<target>
-	output := volume.JoinPathContainer(ctx.Volume.BinDirContainer(), image.ID(), ctx.Name)
+	binaryName := ctx.Name
+	if image.OS() == darwinOS {
+		// replicate how fyne package names the binary
+		binaryName = calculateExeName(volume.JoinPathHost(ctx.WorkDirHost()), image.OS())
+	}
+	output := volume.JoinPathContainer(ctx.Volume.BinDirContainer(), image.ID(), binaryName)
 
 	args = append(args, "-o", output)
 
@@ -270,7 +278,13 @@ func fynePackage(ctx Context, image containerImage) error {
 	// linux, darwin and freebsd targets are built by fyne-cross
 	// in these cases fyne tool is used only to package the app specifying the executable flag
 	if image.OS() == linuxOS || image.OS() == darwinOS || image.OS() == freebsdOS {
-		args = append(args, "-executable", volume.JoinPathContainer(ctx.BinDirContainer(), image.ID(), ctx.Name))
+		binaryName := ctx.Name
+		if image.OS() == darwinOS {
+			// replicate how fyne package names the binary
+			binaryName = calculateExeName(volume.JoinPathHost(ctx.WorkDirHost()), image.OS())
+		}
+
+		args = append(args, "-executable", volume.JoinPathContainer(ctx.BinDirContainer(), image.ID(), binaryName))
 		workDir = volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID())
 	}
 
@@ -283,6 +297,28 @@ func fynePackage(ctx Context, image containerImage) error {
 		return fmt.Errorf("could not package the Fyne app: %v", err)
 	}
 	return nil
+}
+
+func calculateExeName(sourceDir, os string) string {
+	exeName := filepath.Base(sourceDir)
+	/* #nosec */
+	if data, err := ioutil.ReadFile(filepath.Join(sourceDir, "go.mod")); err == nil {
+		modulePath := modfile.ModulePath(data)
+		moduleName, _, ok := module.SplitPathVersion(modulePath)
+		if ok {
+			paths := strings.Split(moduleName, "/")
+			name := paths[len(paths)-1]
+			if name != "" {
+				exeName = name
+			}
+		}
+	}
+
+	if os == "windows" {
+		exeName = exeName + ".exe"
+	}
+
+	return exeName
 }
 
 // fyneRelease package and release the application using the fyne cli tool

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -299,6 +299,7 @@ func fynePackage(ctx Context, image containerImage) error {
 	return nil
 }
 
+// calculateExeName is ported from the fyne base code to ensure darwin binary naming is consistent between fyne-cross and fyne package
 func calculateExeName(sourceDir, os string) string {
 	exeName := filepath.Base(sourceDir)
 	/* #nosec */


### PR DESCRIPTION
This fix replicates how `fyne package` names the executable for darwin, resulting in the binary being named after the module name which is read from `go.mod` 

An example of an app named "Nomad Toml Name" (set in the `toml`) from a module named "nomad"

![image](https://user-images.githubusercontent.com/45520351/202147858-32138ff8-8525-4b33-91b0-3492e87855eb.png)


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

Fixes #139

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

