### PR TITLE
Bugs/propage architecture for local build

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -214,6 +214,7 @@ func fynePackageHost(ctx Context, image containerImage) error {
 	fyneCmd.Dir = ctx.WorkDirHost()
 	fyneCmd.Stdout = os.Stdout
 	fyneCmd.Stderr = os.Stderr
+	fyneCmd.Env = image.AllEnv()
 
 	if debugging() {
 		log.Debug(fyneCmd)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -283,11 +283,15 @@ func fyneReleaseHost(ctx Context, image containerImage) error {
 		}
 	}
 
+	// when using local build, do not assume what CC is available and rely on os.Env("CC") is necessary
+	image.UnsetEnv("CC")
+
 	// run the command from the host
 	fyneCmd := execabs.Command(fyne, args...)
 	fyneCmd.Dir = ctx.WorkDirHost()
 	fyneCmd.Stdout = os.Stdout
 	fyneCmd.Stderr = os.Stderr
+	fyneCmd.Env = append(os.Environ(), image.AllEnv()...)
 
 	if debugging() {
 		log.Debug(fyneCmd)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -209,12 +209,15 @@ func fynePackageHost(ctx Context, image containerImage) error {
 		args = append(args, "-tags", fmt.Sprintf("%q", strings.Join(tags, ",")))
 	}
 
+	// when using local build, do not assume what CC is available and rely on os.Env("CC") is necessary
+	image.UnsetEnv("CC")
+
 	// run the command from the host
 	fyneCmd := execabs.Command(fyne, args...)
 	fyneCmd.Dir = ctx.WorkDirHost()
 	fyneCmd.Stdout = os.Stdout
 	fyneCmd.Stderr = os.Stderr
-	fyneCmd.Env = image.AllEnv()
+	fyneCmd.Env = append(os.Environ(), image.AllEnv()...)
 
 	if debugging() {
 		log.Debug(fyneCmd)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -211,6 +211,8 @@ func fynePackageHost(ctx Context, image containerImage) error {
 
 	// when using local build, do not assume what CC is available and rely on os.Env("CC") is necessary
 	image.UnsetEnv("CC")
+	image.UnsetEnv("CGO_CFLAGS")
+	image.UnsetEnv("CGO_LDFLAGS")
 
 	// run the command from the host
 	fyneCmd := execabs.Command(fyne, args...)
@@ -285,6 +287,8 @@ func fyneReleaseHost(ctx Context, image containerImage) error {
 
 	// when using local build, do not assume what CC is available and rely on os.Env("CC") is necessary
 	image.UnsetEnv("CC")
+	image.UnsetEnv("CGO_CFLAGS")
+	image.UnsetEnv("CGO_LDFLAGS")
 
 	// run the command from the host
 	fyneCmd := execabs.Command(fyne, args...)

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -45,6 +45,7 @@ type containerImage interface {
 	Target() string
 	Env(string) (string, bool)
 	SetEnv(string, string)
+	AllEnv() []string
 	SetMount(string, string, string)
 	AppendTag(string)
 	Tags() []string
@@ -131,6 +132,15 @@ func (a *baseContainerImage) Env(key string) (v string, ok bool) {
 
 func (a *baseContainerImage) SetEnv(key string, value string) {
 	a.env[key] = value
+}
+
+func (a *baseContainerImage) AllEnv() []string {
+	r := []string{}
+
+	for key, value := range a.env {
+		r = append(r, key+"="+value)
+	}
+	return r
 }
 
 func (a *baseContainerImage) SetMount(name string, local string, inContainer string) {

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -45,6 +45,7 @@ type containerImage interface {
 	Target() string
 	Env(string) (string, bool)
 	SetEnv(string, string)
+	UnsetEnv(string)
 	AllEnv() []string
 	SetMount(string, string, string)
 	AppendTag(string)
@@ -132,6 +133,10 @@ func (a *baseContainerImage) Env(key string) (v string, ok bool) {
 
 func (a *baseContainerImage) SetEnv(key string, value string) {
 	a.env[key] = value
+}
+
+func (a *baseContainerImage) UnsetEnv(key string) {
+	delete(a.env, key)
 }
 
 func (a *baseContainerImage) AllEnv() []string {


### PR DESCRIPTION
### Description:
Fix local build when cross compiling. In the case where you for example use a darwin arm64 host and are cross compiling for darwin amd64, the local build path was not propagating the architecture information correctly.

### Checklist:
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.