### PR TITLE
Set certificate and provisioning file before copying ctx.

### DIFF
--- a/internal/command/ios.go
+++ b/internal/command/ios.go
@@ -151,6 +151,9 @@ func (cmd *iOS) setupContainerImages(flags *iosFlags, args []string) error {
 		return fmt.Errorf("appID is mandatory for %s", iosImage)
 	}
 
+	ctx.Certificate = flags.Certificate
+	ctx.Profile = flags.Profile
+
 	cmd.defaultContext = ctx
 	runner, err := newContainerEngine(ctx)
 	if err != nil {
@@ -158,9 +161,6 @@ func (cmd *iOS) setupContainerImages(flags *iosFlags, args []string) error {
 	}
 
 	cmd.Images = append(cmd.Images, runner.createContainerImage("", iosOS, overrideDockerImage(flags.CommonFlags, iosImage)))
-
-	ctx.Certificate = flags.Certificate
-	ctx.Profile = flags.Profile
 
 	return nil
 }


### PR DESCRIPTION
### Description:
defaultContext is not a reference, but ctx is being copied in it. This means setting Certificate and Profile had actually no effect.

Fixes #(issue)

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.