### PR TITLE
ios developer need to sign and provision there application to run on their tests devices.

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -203,6 +203,16 @@ func fynePackageHost(ctx Context, image containerImage) error {
 		args = append(args, "-appID", ctx.AppID)
 	}
 
+	// ios packaging require certificate and profile for running on devices
+	if image.OS() == iosOS {
+		if ctx.Certificate != "" {
+			args = append(args, "-certificate", ctx.Certificate)
+		}
+		if ctx.Profile != "" {
+			args = append(args, "-profile", ctx.Profile)
+		}
+	}
+
 	// add tags to command, if any
 	tags := ctx.Tags
 	if len(tags) > 0 {


### PR DESCRIPTION
### Description:
ios require actually to have any binary running on it to be properly signed and provisioned even when developing not just when pushing stuff to the store.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

