### PR TITLE
Display binaryName as that will be the correct name on all platform.

### DIFF
--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -228,7 +228,7 @@ func goBuild(ctx Context, image containerImage) error {
 		return err
 	}
 
-	log.Infof("[✓] Binary: %s", volume.JoinPathHost(ctx.BinDirHost(), image.ID(), ctx.Name))
+	log.Infof("[✓] Binary: %s", volume.JoinPathHost(ctx.BinDirHost(), image.ID(), binaryName))
 	return nil
 }
 


### PR DESCRIPTION
### Description:
Just a cosmetic fixup to display the correct binary name on darwin platform.

### Checklist:
- [ ] Tests all pass.
