### PR TITLE
Allow to set up the executable name from the command line.

### DIFF
--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -205,8 +206,15 @@ func goBuild(ctx Context, image containerImage) error {
 	}
 
 	// set output folder to fyne-cross/bin/<target>
-	binaryName := ctx.Name
+	binaryName := ctx.ExecutableName
+	if binaryName == "" {
+		binaryName = ctx.Name
+	}
 	if image.OS() == darwinOS {
+		if ctx.Engine.Name == kubernetesEngine && ctx.ExecutableName == "" {
+			return errors.New("executable name is required for darwinOS on kubernetes engine (use --executable-name)")
+		}
+
 		// replicate how fyne package names the binary
 		binaryName = calculateExeName(volume.JoinPathHost(ctx.WorkDirHost()), image.OS())
 	}

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -53,6 +53,7 @@ type Context struct {
 	CacheEnabled     bool   // CacheEnabled if true enable go build cache
 	Icon             string // Icon is the optional icon in png format to use for distribution
 	Name             string // Name is the application name
+	ExecutableName   string // ExecutableName is the name of the executable to be generated
 	Package          string // Package is the package to build named by the import path as per 'go build'
 	Release          bool   // Enable release mode. If true, prepares an application for public distribution
 	StripDebug       bool   // StripDebug if true, strips binary output
@@ -136,6 +137,7 @@ func makeDefaultContext(flags *CommonFlags, args []string) (Context, error) {
 		Tags:             flags.Tags,
 		Icon:             flags.Icon,
 		Name:             flags.Name,
+		ExecutableName:   flags.ExecutableName,
 		StripDebug:       !flags.NoStripDebug,
 		Debug:            flags.Debug,
 		Volume:           vol,

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -55,6 +55,8 @@ type CommonFlags struct {
 	NoStripDebug bool
 	// Name represents the application name
 	Name string
+	// ExecutableName represents the name of the executable
+	ExecutableName string
 	// Release represents if the package should be prepared for release (disable debug etc)
 	Release bool
 	// RootDir represents the project root directory
@@ -123,6 +125,7 @@ func newCommonFlags() (*CommonFlags, error) {
 	flagSet.Var(&flags.Tags, "tags", "List of additional build tags separated by comma")
 	flagSet.BoolVar(&flags.NoStripDebug, "no-strip-debug", false, "Do not strip debug information from binaries")
 	flagSet.StringVar(&flags.Name, "name", name, "The name of the application")
+	flagSet.StringVar(&flags.ExecutableName, "executable-name", name, "The name of the executable")
 	flagSet.StringVar(&flags.Name, "output", name, "Named output file. Deprecated in favour of 'name'")
 	flagSet.BoolVar(&flags.Release, "release", false, "Release mode. Prepares the application for public distribution")
 	flagSet.StringVar(&flags.RootDir, "dir", rootDir, "Fyne app root directory")


### PR DESCRIPTION
### Description:

This allow to mimic the executable name picked by fyne build command. I think this is another issue with not using fyne directly for building. I will be investigating switching more platform to build with fyne directly as a permanent fix for this serie of problem.

### Checklist:
- [ ] Tests all pass.
