### PR TITLE
Features/use fyne build

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -141,16 +141,6 @@ func prepareIcon(ctx Context, image containerImage) error {
 		}
 	}
 
-	if image.OS() == "windows" {
-		// convert the png icon to ico format and store under the temp directory
-		icoIcon := volume.JoinPathHost(ctx.TmpDirHost(), image.ID(), ctx.Name+".ico")
-		err := icon.ConvertPngToIco(ctx.Icon, icoIcon)
-		if err != nil {
-			return fmt.Errorf("could not create the windows ico: %v", err)
-		}
-		return nil
-	}
-
 	err := image.Run(ctx.Volume, options{}, []string{"cp", volume.JoinPathContainer(ctx.WorkDirContainer(), ctx.Icon), volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID(), icon.Default)})
 	if err != nil {
 		return fmt.Errorf("could not copy the icon to temp folder: %v", err)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/fyne-io/fyne-cross/internal/icon"
 	"github.com/fyne-io/fyne-cross/internal/log"
-	"github.com/fyne-io/fyne-cross/internal/metadata"
 	"github.com/fyne-io/fyne-cross/internal/volume"
 	"golang.org/x/sys/execabs"
 )
@@ -31,16 +30,11 @@ type closer interface {
 }
 
 func commonRun(defaultContext Context, images []containerImage, builder platformBuilder) error {
-	err := bumpFyneAppBuild(defaultContext)
-	if err != nil {
-		log.Infof("[i] FyneApp.toml: unable to bump the build number. Error: %s", err)
-	}
-
 	for _, image := range images {
 		log.Infof("[i] Target: %s/%s", image.OS(), image.Architecture())
 		log.Debugf("%#v", image)
 
-		err = func() error {
+		err := func() error {
 			defer image.(closer).close()
 
 			//
@@ -50,7 +44,7 @@ func commonRun(defaultContext Context, images []containerImage, builder platform
 				return err
 			}
 
-			err = cleanTargetDirs(defaultContext, image)
+			err := cleanTargetDirs(defaultContext, image)
 			if err != nil {
 				return err
 			}
@@ -294,15 +288,4 @@ func fyneReleaseHost(ctx Context, image containerImage) error {
 		return fmt.Errorf("could not package the Fyne app: %v", err)
 	}
 	return nil
-}
-
-// bumpFyneAppBuild increments the BuildID into the FyneApp.toml, if any,
-// to behave like the fyne CLI tool
-func bumpFyneAppBuild(ctx Context) error {
-	data, err := metadata.LoadStandard(ctx.Volume.WorkDirHost())
-	if err != nil {
-		return nil // no metadata to update
-	}
-	data.Details.Build++
-	return metadata.SaveStandard(data, ctx.Volume.WorkDirHost())
 }

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -2,16 +2,12 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/icon"
 	"github.com/fyne-io/fyne-cross/internal/log"
 	"github.com/fyne-io/fyne-cross/internal/volume"
-	"golang.org/x/mod/modfile"
-	"golang.org/x/mod/module"
 )
 
 const (
@@ -169,69 +165,6 @@ func goModInit(ctx Context, image containerImage) error {
 	return nil
 }
 
-// goBuild run the go build command in the container
-func goBuild(ctx Context, image containerImage) error {
-	log.Infof("[i] Building binary...")
-	// add go build command
-	args := []string{"go", "build", "-trimpath"}
-
-	// Strip debug information
-	if ctx.StripDebug {
-		// ensure that CGO_LDFLAGS is not overwritten as they can be passed
-		// by the --env argument
-		if v, ok := image.Env("CGO_LDFLAGS"); ok {
-			// append the ldflags after the existing CGO_LDFLAGS
-			image.SetEnv("CGO_LDFLAGS", strings.Trim(v, "\"")+" -w -s")
-		} else {
-			// create the CGO_LDFLAGS environment variable and add the strip debug flags
-			image.SetEnv("CGO_LDFLAGS", "-w -s")
-		}
-	}
-
-	ldflags := ctx.LdFlags
-	// honour the GOFLAGS env variable adding to existing ones
-	if v, ok := image.Env("GOFLAGS"); ok {
-		ldflags = append(ldflags, v)
-	}
-
-	if len(ldflags) > 0 {
-		args = append(args, "-ldflags", strings.Join(ldflags, " "))
-	}
-
-	// add tags to command, if any
-	tags := image.Tags()
-	if len(tags) > 0 {
-		args = append(args, "-tags", strings.Join(tags, ","))
-	}
-
-	// set output folder to fyne-cross/bin/<target>
-	binaryName := ctx.Name
-	if image.OS() == darwinOS {
-		// replicate how fyne package names the binary
-		binaryName = calculateExeName(volume.JoinPathHost(ctx.WorkDirHost()), image.OS())
-	}
-	output := volume.JoinPathContainer(ctx.Volume.BinDirContainer(), image.ID(), binaryName)
-
-	args = append(args, "-o", output)
-
-	// enable debug mode
-	if debugging() {
-		args = append(args, "-v")
-	}
-
-	//add package
-	args = append(args, ctx.Package)
-
-	err := image.Run(ctx.Volume, options{}, args)
-
-	if err != nil {
-		return err
-	}
-
-	log.Infof("[✓] Binary: %s", volume.JoinPathHost(ctx.BinDirHost(), image.ID(), ctx.Name))
-	return nil
-}
-
 func fyneCommand(command string, ctx Context, image containerImage) ([]string, error) {
 	if debugging() {
 		err := image.Run(ctx.Volume, options{}, []string{fyneBin, "version"})
@@ -279,18 +212,7 @@ func fynePackage(ctx Context, image containerImage) error {
 		workDir = volume.JoinPathContainer(workDir, ctx.Package)
 	}
 
-	// linux, darwin and freebsd targets are built by fyne-cross
-	// in these cases fyne tool is used only to package the app specifying the executable flag
-	if image.OS() == linuxOS || image.OS() == darwinOS || image.OS() == freebsdOS {
-		binaryName := ctx.Name
-		if image.OS() == darwinOS {
-			// replicate how fyne package names the binary
-			binaryName = calculateExeName(volume.JoinPathHost(ctx.WorkDirHost()), image.OS())
-		}
-
-		args = append(args, "-executable", volume.JoinPathContainer(ctx.BinDirContainer(), image.ID(), binaryName))
-		workDir = volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID())
-	} else if ctx.StripDebug {
+	if ctx.StripDebug {
 		args = append(args, "-release")
 	}
 
@@ -303,29 +225,6 @@ func fynePackage(ctx Context, image containerImage) error {
 		return fmt.Errorf("could not package the Fyne app: %v", err)
 	}
 	return nil
-}
-
-// calculateExeName is ported from the fyne base code to ensure darwin binary naming is consistent between fyne-cross and fyne package
-func calculateExeName(sourceDir, os string) string {
-	exeName := filepath.Base(sourceDir)
-	/* #nosec */
-	if data, err := ioutil.ReadFile(filepath.Join(sourceDir, "go.mod")); err == nil {
-		modulePath := modfile.ModulePath(data)
-		moduleName, _, ok := module.SplitPathVersion(modulePath)
-		if ok {
-			paths := strings.Split(moduleName, "/")
-			name := paths[len(paths)-1]
-			if name != "" {
-				exeName = name
-			}
-		}
-	}
-
-	if os == windowsOS {
-		exeName = exeName + ".exe"
-	}
-
-	return exeName
 }
 
 // fyneRelease package and release the application using the fyne cli tool
@@ -381,35 +280,4 @@ func fyneRelease(ctx Context, image containerImage) error {
 		return fmt.Errorf("could not package the Fyne app: %v", err)
 	}
 	return nil
-}
-
-// WindowsResource create a windows resource under the project root
-// that will be automatically linked by compliler during the build
-func WindowsResource(ctx Context, image containerImage) (string, error) {
-	args := []string{
-		gowindresBin,
-		"-arch", image.Architecture().String(),
-		"-output", ctx.Name,
-		"-workdir", volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID()),
-	}
-
-	runOpts := options{
-		WorkDir: volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID()),
-	}
-
-	err := image.Run(ctx.Volume, runOpts, args)
-	if err != nil {
-		return "", fmt.Errorf("could not package the Fyne app: %v", err)
-	}
-
-	// copy the windows resource under the package root
-	// it will be automatically linked by compiler during build
-	windres := ctx.Name + ".syso"
-	out := filepath.Join(ctx.Package, windres)
-	err = volume.Copy(volume.JoinPathHost(ctx.TmpDirHost(), image.ID(), windres), volume.JoinPathHost(ctx.WorkDirHost(), out))
-	if err != nil {
-		return "", fmt.Errorf("could not copy windows resource under the package root: %v", err)
-	}
-
-	return out, nil
 }

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -13,8 +13,6 @@ import (
 const (
 	// fyneBin is the path of the fyne binary into the docker image
 	fyneBin = "/usr/local/bin/fyne"
-	// gowindresBin is the path of the gowindres binary into the docker image
-	gowindresBin = "/usr/local/bin/gowindres"
 )
 
 type containerEngine interface {

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -107,12 +107,6 @@ func (cmd *darwin) Build(image containerImage) (string, error) {
 			return "", fmt.Errorf("could not package the Fyne app: %v", err)
 		}
 
-		// move the dist package into the expected tmp/$ID/packageName location in the container
-		image.Run(cmd.defaultContext.Volume, options{}, []string{
-			"mv",
-			volume.JoinPathContainer(cmd.defaultContext.WorkDirContainer(), packageName),
-			volume.JoinPathContainer(cmd.defaultContext.TmpDirContainer(), image.ID(), packageName),
-		})
 	} else if cmd.localBuild {
 		packageName = fmt.Sprintf("%s.app", cmd.defaultContext.Name)
 
@@ -120,19 +114,7 @@ func (cmd *darwin) Build(image containerImage) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not package the Fyne app: %v", err)
 		}
-
-		// move the dist package into the expected tmp/$ID/packageName location in the container
-		image.Run(cmd.defaultContext.Volume, options{}, []string{
-			"mv",
-			volume.JoinPathContainer(cmd.defaultContext.WorkDirContainer(), packageName),
-			volume.JoinPathContainer(cmd.defaultContext.TmpDirContainer(), image.ID(), packageName),
-		})
 	} else {
-		err = goBuild(cmd.defaultContext, image)
-		if err != nil {
-			return "", err
-		}
-
 		packageName = fmt.Sprintf("%s.app", cmd.defaultContext.Name)
 
 		err = fynePackage(cmd.defaultContext, image)
@@ -140,6 +122,13 @@ func (cmd *darwin) Build(image containerImage) (string, error) {
 			return "", fmt.Errorf("could not package the Fyne app: %v", err)
 		}
 	}
+
+	// move the dist package into the expected tmp/$ID/packageName location in the container
+	image.Run(cmd.defaultContext.Volume, options{}, []string{
+		"mv",
+		volume.JoinPathContainer(cmd.defaultContext.WorkDirContainer(), packageName),
+		volume.JoinPathContainer(cmd.defaultContext.TmpDirContainer(), image.ID(), packageName),
+	})
 
 	return packageName, nil
 }

--- a/internal/command/docker_test.go
+++ b/internal/command/docker_test.go
@@ -267,3 +267,8 @@ func TestCmdEnginePodman(t *testing.T) {
 		})
 	}
 }
+
+func TestMain(m *testing.M) {
+	os.Unsetenv("SSH_AUTH_SOCK")
+	os.Exit(m.Run())
+}

--- a/internal/command/freebsd.go
+++ b/internal/command/freebsd.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/fyne-io/fyne-cross/internal/log"
+	"github.com/fyne-io/fyne-cross/internal/volume"
 )
 
 const (
@@ -70,29 +71,31 @@ func (cmd *freeBSD) Parse(args []string) error {
 // Run runs the command
 func (cmd *freeBSD) Build(image containerImage) (string, error) {
 	//
-	// build
-	//
-	err := goBuild(cmd.defaultContext, image)
-	if err != nil {
-		return "", err
-	}
-
-	//
 	// package
 	//
 	log.Info("[i] Packaging app...")
-
 	packageName := fmt.Sprintf("%s.tar.xz", cmd.defaultContext.Name)
 
-	err = prepareIcon(cmd.defaultContext, image)
+	err := prepareIcon(cmd.defaultContext, image)
 	if err != nil {
 		return "", err
 	}
 
-	err = fynePackage(cmd.defaultContext, image)
+	if cmd.defaultContext.Release {
+		// Release mode
+		err = fyneRelease(cmd.defaultContext, image)
+	} else {
+		// Build mode
+		err = fynePackage(cmd.defaultContext, image)
+	}
 	if err != nil {
 		return "", fmt.Errorf("could not package the Fyne app: %v", err)
 	}
+	image.Run(cmd.defaultContext.Volume, options{}, []string{
+		"mv",
+		volume.JoinPathContainer(cmd.defaultContext.WorkDirContainer(), packageName),
+		volume.JoinPathContainer(cmd.defaultContext.TmpDirContainer(), image.ID(), packageName),
+	})
 
 	return packageName, nil
 }


### PR DESCRIPTION
### Description:
This remove an historic piece of software that has done a lot to enable this tool, but it has past it's usefulness. By removing it and relying on fyne build directly, this fixes a lot of problem due to fyne-cross trying to reproduce fyne build and not always being able to.

I have tested all the platform impacted (darwin, linux, windows and freebsd), but it would be good to have more people testing this.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
