### PR TITLE
Address issue when using -dir and ctx.Icon can't be found.

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/icon"
@@ -122,8 +123,8 @@ func cleanTargetDirs(ctx Context, image containerImage) error {
 func prepareIcon(ctx Context, image containerImage) error {
 	if !ctx.NoProjectUpload {
 		iconPath := ctx.Icon
-		if ctx.Icon[0] != os.PathSeparator {
-			iconPath = volume.JoinPathContainer(ctx.WorkDirHost(), ctx.Icon)
+		if !filepath.IsAbs(ctx.Icon) {
+			iconPath = volume.JoinPathHost(ctx.WorkDirHost(), ctx.Icon)
 		}
 
 		if _, err := os.Stat(iconPath); os.IsNotExist(err) {
@@ -132,7 +133,7 @@ func prepareIcon(ctx Context, image containerImage) error {
 			}
 
 			log.Infof("[!] Default icon not found at %q", ctx.Icon)
-			err = ioutil.WriteFile(volume.JoinPathContainer(ctx.WorkDirHost(), ctx.Icon), icon.FyneLogo, 0644)
+			err = ioutil.WriteFile(volume.JoinPathHost(ctx.WorkDirHost(), ctx.Icon), icon.FyneLogo, 0644)
 			if err != nil {
 				return fmt.Errorf("could not create the temporary icon: %s", err)
 			}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -121,7 +121,12 @@ func cleanTargetDirs(ctx Context, image containerImage) error {
 // prepareIcon prepares the icon for packaging
 func prepareIcon(ctx Context, image containerImage) error {
 	if !ctx.NoProjectUpload {
-		if _, err := os.Stat(ctx.Icon); os.IsNotExist(err) {
+		iconPath := ctx.Icon
+		if ctx.Icon[0] != os.PathSeparator {
+			iconPath = volume.JoinPathContainer(ctx.WorkDirHost(), ctx.Icon)
+		}
+
+		if _, err := os.Stat(iconPath); os.IsNotExist(err) {
 			if ctx.Icon != icon.Default {
 				return fmt.Errorf("icon not found at %q", ctx.Icon)
 			}


### PR DESCRIPTION
### Description:
This make it possible to compile in a subdirectory using -dir by doing the proper lookup for the Icon specified on the command line.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
