### PR TITLE
Windows version actually expect 3 digits by default.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         go-version: "1.18.x"
 
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      run: go install honnef.co/go/tools/cmd/staticcheck@2023.1
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         go-version: "1.18.x"
 
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@2023.1
+      run: go install honnef.co/go/tools/cmd/staticcheck@latest
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup Go environment
       uses: actions/setup-go@v3
       with:
-        go-version: "1.18.x"
+        go-version: "1.19.x"
 
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -86,7 +86,7 @@ func newCommonFlags() (*CommonFlags, error) {
 
 	defaultIcon := icon.Default
 	appID := ""
-	appVersion := "1.0"
+	appVersion := "1.0.0"
 	appBuild := 1
 
 	data, _ := metadata.LoadStandard(rootDir)


### PR DESCRIPTION
### Description:
Windows executable version must have 3 independent digits to be accepted by Windows. Fyne should correct the version, but it would be best to have correct default value.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.