### PR TITLE
zig does ignore ldflags passed by go, we need to specify them on zig …

### DIFF
--- a/internal/command/windows.go
+++ b/internal/command/windows.go
@@ -213,16 +213,16 @@ func (cmd *windows) setupContainerImages(flags *windowsFlags, args []string) err
 		switch arch {
 		case ArchAmd64:
 			image.SetEnv("GOARCH", "amd64")
-			image.SetEnv("CC", "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype")
-			image.SetEnv("CXX", "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype")
+			image.SetEnv("CC", "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows")
+			image.SetEnv("CXX", "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows")
 		case Arch386:
 			image.SetEnv("GOARCH", "386")
-			image.SetEnv("CC", "zig cc -target x86-windows-gnu -Wdeprecated-non-prototype")
-			image.SetEnv("CXX", "zig c++ -target x86-windows-gnu -Wdeprecated-non-prototype")
+			image.SetEnv("CC", "zig cc -target x86-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows")
+			image.SetEnv("CXX", "zig c++ -target x86-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows")
 		case ArchArm64:
 			image.SetEnv("GOARCH", "arm64")
-			image.SetEnv("CC", "zig cc -target aarch64-windows-gnu -Wdeprecated-non-prototype")
-			image.SetEnv("CXX", "zig c++ -target aarch64-windows-gnu -Wdeprecated-non-prototype")
+			image.SetEnv("CC", "zig cc -target aarch64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows")
+			image.SetEnv("CXX", "zig c++ -target aarch64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows")
 		}
 
 		cmd.Images = append(cmd.Images, image)

--- a/internal/command/windows_test.go
+++ b/internal/command/windows_test.go
@@ -52,7 +52,7 @@ func Test_makeWindowsContext(t *testing.T) {
 						arch: "amd64",
 						os:   "windows",
 						id:   "windows-amd64",
-						env:  map[string]string{"GOOS": "windows", "GOARCH": "amd64", "CC": "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype", "CXX": "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype"},
+						env:  map[string]string{"GOOS": "windows", "GOARCH": "amd64", "CC": "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows", "CXX": "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows"},
 						mount: []containerMountPoint{
 							{"project", vol.WorkDirHost(), vol.WorkDirContainer()},
 							{"cache", vol.CacheDirHost(), vol.CacheDirContainer()},
@@ -88,7 +88,7 @@ func Test_makeWindowsContext(t *testing.T) {
 						arch: "386",
 						os:   "windows",
 						id:   "windows-386",
-						env:  map[string]string{"GOOS": "windows", "GOARCH": "386", "CC": "zig cc -target x86-windows-gnu -Wdeprecated-non-prototype", "CXX": "zig c++ -target x86-windows-gnu -Wdeprecated-non-prototype"},
+						env:  map[string]string{"GOOS": "windows", "GOARCH": "386", "CC": "zig cc -target x86-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows", "CXX": "zig c++ -target x86-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows"},
 						mount: []containerMountPoint{
 							{"project", vol.WorkDirHost(), vol.WorkDirContainer()},
 							{"cache", vol.CacheDirHost(), vol.CacheDirContainer()},
@@ -126,7 +126,7 @@ func Test_makeWindowsContext(t *testing.T) {
 						arch: "amd64",
 						os:   "windows",
 						id:   "windows-amd64",
-						env:  map[string]string{"GOOS": "windows", "GOARCH": "amd64", "CC": "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype", "CXX": "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype"},
+						env:  map[string]string{"GOOS": "windows", "GOARCH": "amd64", "CC": "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows", "CXX": "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows"},
 						mount: []containerMountPoint{
 							{"project", vol.WorkDirHost(), vol.WorkDirContainer()},
 							{"cache", vol.CacheDirHost(), vol.CacheDirContainer()},
@@ -162,7 +162,7 @@ func Test_makeWindowsContext(t *testing.T) {
 						arch: "amd64",
 						os:   "windows",
 						id:   "windows-amd64",
-						env:  map[string]string{"GOOS": "windows", "GOARCH": "amd64", "CC": "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype", "CXX": "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype"},
+						env:  map[string]string{"GOOS": "windows", "GOARCH": "amd64", "CC": "zig cc -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows", "CXX": "zig c++ -target x86_64-windows-gnu -Wdeprecated-non-prototype -Wl,--subsystem,windows"},
 						mount: []containerMountPoint{
 							{"project", vol.WorkDirHost(), vol.WorkDirContainer()},
 							{"cache", vol.CacheDirHost(), vol.CacheDirContainer()},


### PR DESCRIPTION
### Description:
As zig ignore LDFLAGS, we need to provide them in an alternate way. Maybe it would be good to have `fyne build` detect zig and do that somehow, but that seems more complex work.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
