### PR TITLE
Add ability to bypass darwin sdk on image test.

### DIFF
--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -67,7 +67,7 @@ func (cmd *darwin) Parse(args []string) error {
 	if runtime.GOOS == darwinOS {
 		flagSet.BoolVar(&cmd.localBuild, "local", true, "If set uses the fyne CLI tool installed on the host in place of the docker images")
 	} else {
-		flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK [required]")
+		flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK (setting it to 'ignore' will skip the in container sdk check) [required]")
 	}
 
 	// flags used only in release mode

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -244,7 +244,7 @@ func (cmd *darwin) setupContainerImages(flags *darwinFlags, args []string) error
 				if err != nil {
 					return errors.New("macOSX SDK path is mandatory")
 				}
-			} else {
+			} else if flags.MacOSXSDKPath != "ignore" {
 				if _, err := os.Stat(flags.MacOSXSDKPath); os.IsNotExist(err) {
 					return errors.New("macOSX SDK path does not exists")
 				}

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -67,7 +67,7 @@ func (cmd *darwin) Parse(args []string) error {
 	if runtime.GOOS == darwinOS {
 		flagSet.BoolVar(&cmd.localBuild, "local", true, "If set uses the fyne CLI tool installed on the host in place of the docker images")
 	} else {
-		flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK (setting it to 'ignore' will skip the in container sdk check) [required]")
+		flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK (setting it to 'bundled' indicate that the sdk is expected to be in the container) [required]")
 	}
 
 	// flags used only in release mode
@@ -244,7 +244,7 @@ func (cmd *darwin) setupContainerImages(flags *darwinFlags, args []string) error
 				if err != nil {
 					return errors.New("macOSX SDK path is mandatory")
 				}
-			} else if flags.MacOSXSDKPath != "ignore" {
+			} else if flags.MacOSXSDKPath != "bundled" {
 				if _, err := os.Stat(flags.MacOSXSDKPath); os.IsNotExist(err) {
 					return errors.New("macOSX SDK path does not exists")
 				}

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -67,7 +67,7 @@ func (cmd *darwin) Parse(args []string) error {
 	if runtime.GOOS == darwinOS {
 		flagSet.BoolVar(&cmd.localBuild, "local", true, "If set uses the fyne CLI tool installed on the host in place of the docker images")
 	} else {
-		flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK (setting it to 'bundled' indicate that the sdk is expected to be in the container) [required]")
+		flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK (setting it to 'bundled' indicates that the sdk is expected to be in the container) [required]")
 	}
 
 	// flags used only in release mode


### PR DESCRIPTION
In the case of using Kubernetes backend, the container isn't started and accessible before we start the image with Prepare. It is simpler to just not try to test when we know what we are doing.

This was suggested during the previous and it is in practice a good solution.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
