### PR TITLE
Remove gles tag now that we rely on fyne to do the right things for us.

### DIFF
--- a/internal/command/linux.go
+++ b/internal/command/linux.go
@@ -176,13 +176,11 @@ func (cmd *linux) setupContainerImages(flags *linuxFlags, args []string) error {
 			image.SetEnv("GOARM", "7")
 			image.SetEnv("CC", "zig cc -target arm-linux-gnueabihf -isystem /usr/include -L/usr/lib/arm-linux-gnueabihf")
 			image.SetEnv("CXX", "zig c++ -target arm-linux-gnueabihf -isystem /usr/include -L/usr/lib/arm-linux-gnueabihf")
-			image.AppendTag("gles")
 		case ArchArm64:
 			image = runner.createContainerImage(arch, linuxOS, overrideDockerImage(flags.CommonFlags, linuxImageArm64))
 			image.SetEnv("GOARCH", "arm64")
 			image.SetEnv("CC", "zig cc -target aarch64-linux-gnu -isystem /usr/include -L/usr/lib/aarch64-linux-gnu")
 			image.SetEnv("CXX", "zig c++ -target aarch64-linux-gnu -isystem /usr/include -L/usr/lib/aarch64-linux-gnu")
-			image.AppendTag("gles")
 		}
 
 		image.SetEnv("GOOS", "linux")


### PR DESCRIPTION
### Description:
As highlighted during the review of PR 1.4.0, we do not need anymore the gles tag for linux arm target. I verified on my PineBook Pro and this work.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
