### PR TITLE
Remove fixuid, handle user permissions directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     # Checks-out the repository under $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Run linters
     - name: Run go vet
@@ -44,7 +44,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     # Checks-out the repository under $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Run tests
     - run: go test -v -cover -race ./...
@@ -66,7 +66,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     # Checks-out the repository under $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Run tests
     - run: go build -tags k8s
@@ -108,12 +108,12 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: fyne-cross
 
       - name: Checkout fyne-io/calculator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: fyne-io/calculator
           path: calculator
@@ -190,12 +190,12 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: fyne-cross
 
       - name: Checkout fyne-io/terminal
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: fyne-io/terminal
           path: terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog - Fyne.io fyne-cross
 
-## Unreleased
+## 1.4.0 - 13 Mar 2023
+
+### Added
+
+- Add support for Kubernetes
+- Add ability to specify a different registry
+- Support for fyne metadata
+
+### Changed
+
+- Pull image from fyne-cross-image repository
+- Simplify `fyne-cross darwin-sdk-extract` by getting the needed files from the Apple SDK and then mounting them in the container image for each build
+- Provide a darwin image and mount the SDK from the host
+- Use `fyne build` for all targets
 
 ## 1.3.0 - 16 Jul 2022
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Supported targets are:
 > - starting from v1.1.0:
 >   - cross-compile from NOT `darwin` (i.e. linux) to `darwin`: requires a copy of the macOS SDK on the host. The fyne-cross `darwin-sdk-extractor` command can be used to extract the SDK from the XCode CLI Tool file, see the [Extract the macOS SDK](#extract_macos_sdk) section below.
 >   - cross-compile from `darwin` to `darwin` by default will use under the hood the fyne CLI tool and requires Go and the macOS SDK installed on the host.
+> - starting from v1.4.0, Arm64 hosts are supported for all platforms except Android.
 
 ## Requirements
 
@@ -45,7 +46,7 @@ For go >= 1.16:
 go install github.com/fyne-io/fyne-cross@latest
 ```
 
-To install a fyne-cross with kubernetes engine:
+To install a fyne-cross with kubernetes engine support:
 ```
 go install -tags k8s github.com/fyne-io/fyne-cross@latest
 ```
@@ -86,18 +87,6 @@ The commands are:
 	version       Print the fyne-cross version information
 
 Use "fyne-cross <command> -help" for more information about a command.
-```
-
-### Apple Arm Silicon special
-
-On Apple Arm64 architecture, the container have to run in a vm. This vm put some constraint on getting fyne-cross to work in that setup.
-
-## podman on Mac Mini M1
-
-You need to create a `podman machine` that has a short name as the access path on Mac can not be over 104 and that limit can be reached quickly when the machine name is to long. Additionally you need to specify in the machine the path that you might need during your build. An example of possible machine to use:
-
-```
-podman machine init --now machine --cpus=8 --memory=6096  -v /tmp:/tmp -v ${HOME}:${HOME}
 ```
 
 ### Wildcards

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -60,6 +60,7 @@ type Context struct {
 	Pull             bool   // Pull if true attempts to pull a newer version of the docker image
 	NoProjectUpload  bool   // NoProjectUpload if true, the build will be done with the artifact already stored on S3
 	NoResultDownload bool   // NoResultDownload if true, the result of the build will be left on S3 and not downloaded locally
+	NoNetwork        bool   // NoNetwork if true, the build will be done without network access
 
 	//Build context
 	BuildMode string // The -buildmode argument to pass to go build
@@ -142,6 +143,7 @@ func makeDefaultContext(flags *CommonFlags, args []string) (Context, error) {
 		Name:             flags.Name,
 		StripDebug:       !flags.NoStripDebug,
 		Debug:            flags.Debug,
+		NoNetwork:        flags.NoNetwork,
 		Volume:           vol,
 		Pull:             flags.Pull,
 		Release:          flags.Release,

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -27,6 +27,7 @@ type localContainerEngine struct {
 
 	pull         bool
 	cacheEnabled bool
+	noNetwork    bool
 }
 
 func newLocalContainerEngine(context Context) (containerEngine, error) {
@@ -39,6 +40,7 @@ func newLocalContainerEngine(context Context) (containerEngine, error) {
 		engine:       &context.Engine,
 		pull:         context.Pull,
 		cacheEnabled: context.CacheEnabled,
+		noNetwork:    context.NoNetwork,
 	}, nil
 }
 
@@ -150,6 +152,10 @@ func (i *localContainerImage) cmd(vol volume.Volume, opts options, cmdArgs []str
 		"-e", "CGO_ENABLED=1", // enable CGO
 		"-e", fmt.Sprintf("GOCACHE=%s", vol.GoCacheDirContainer()), // mount GOCACHE to reuse cache between builds
 	)
+
+	if i.runner.noNetwork {
+		args = append(args, "--network=none")
+	}
 
 	// add custom env variables
 	args = AppendEnv(args, i.runner.env, i.env["GOOS"] != freebsdOS)

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -129,11 +129,14 @@ func (i *localContainerImage) cmd(vol volume.Volume, opts options, cmdArgs []str
 		if runtime.GOOS != "windows" {
 			u, err := user.Current()
 			if err == nil {
-				args = append(args, "-u", fmt.Sprintf("%s:%s", u.Uid, u.Gid))
-				args = append(args, "--entrypoint", "fixuid")
-				if !debugging() {
-					// silent fixuid if not debug mode
-					cmdArgs = append([]string{"-q"}, cmdArgs...)
+				// Container runs as current host UID
+				args = append(args, "--user", u.Uid)
+				// Set HOME to something writable by the user
+				args = append(args, "-e", "HOME=/home/user")
+				// Map host zig cache if host user has a HOME
+				home := os.Getenv("HOME")
+				if home != "" {
+					args = append(args, "-v", fmt.Sprintf("%s/.cache/zig:/home/user/.cache/zig", home))
 				}
 			}
 		}

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -135,7 +135,7 @@ func (i *localContainerImage) cmd(vol volume.Volume, opts options, cmdArgs []str
 				args = append(args, "-e", "HOME=/home/user")
 				// Map host zig cache if host user has a HOME
 				home := os.Getenv("HOME")
-				if home != "" {
+				if home != "" && i.runner.cacheEnabled {
 					args = append(args, "-v", fmt.Sprintf("%s/.cache/zig:/home/user/.cache/zig", home))
 				}
 			}

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -132,12 +132,7 @@ func (i *localContainerImage) cmd(vol volume.Volume, opts options, cmdArgs []str
 				// Container runs as current host UID
 				args = append(args, "--user", u.Uid)
 				// Set HOME to something writable by the user
-				args = append(args, "-e", "HOME=/home/user")
-				// Map host zig cache if host user has a HOME
-				home := os.Getenv("HOME")
-				if home != "" && i.runner.cacheEnabled {
-					args = append(args, "-v", fmt.Sprintf("%s/.cache/zig:/home/user/.cache/zig", home))
-				}
+				args = append(args, "-e", "HOME=/tmp")
 			}
 		}
 	}

--- a/internal/command/docker_test.go
+++ b/internal/command/docker_test.go
@@ -66,7 +66,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, uid.Uid, home, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/home/user -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, dockerImage),
 		},
 		{
@@ -84,7 +84,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, uid.Uid, home, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform %s/%s --user %s -e HOME=/home/user -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, dockerImage),
 		},
 		{
@@ -101,7 +101,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, uid.Uid, home, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform %s/%s --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, runtime.GOOS, runtime.GOARCH, uid.Uid, home, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, dockerImage),
 		},
 		{
@@ -119,7 +119,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, uid.Uid, home, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/home/user -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, dockerImage),
 		},
 	}

--- a/internal/command/docker_test.go
+++ b/internal/command/docker_test.go
@@ -27,6 +27,12 @@ func TestCmdEngineDocker(t *testing.T) {
 	log.Println(expectedCmd)
 
 	uid, _ := user.Current()
+	mountFlag := ":z"
+	if runtime.GOOS == darwinOS && runtime.GOARCH == string(ArchArm64) {
+		// When running on darwin with a Arm64, we rely on going through a VM setup that doesn't allow the :z
+		mountFlag = ""
+	}
+
 
 	workDir := filepath.Join(os.TempDir(), "fyne-cross-test", "app")
 	cacheDir := filepath.Join(os.TempDir(), "fyne-cross-test", "cache")
@@ -65,7 +71,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app%s --platform linux/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, mountFlag, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, dockerImage),
 		},
 		{
@@ -83,7 +89,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app%s --platform linux/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, mountFlag, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, dockerImage),
 		},
 		{
@@ -100,7 +106,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app%s -v %s:/go%s --platform linux/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, mountFlag, cacheDir, mountFlag, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, dockerImage),
 		},
 		{
@@ -118,7 +124,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app%s --platform linux/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, mountFlag, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, dockerImage),
 		},
 	}

--- a/internal/command/docker_test.go
+++ b/internal/command/docker_test.go
@@ -27,7 +27,6 @@ func TestCmdEngineDocker(t *testing.T) {
 	log.Println(expectedCmd)
 
 	uid, _ := user.Current()
-	home := os.Getenv("HOME")
 
 	workDir := filepath.Join(os.TempDir(), "fyne-cross-test", "app")
 	cacheDir := filepath.Join(os.TempDir(), "fyne-cross-test", "cache")
@@ -66,7 +65,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/home/user -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, dockerImage),
 		},
 		{
@@ -84,7 +83,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform %s/%s --user %s -e HOME=/home/user -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, dockerImage),
 		},
 		{
@@ -101,7 +100,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform %s/%s --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, runtime.GOOS, runtime.GOARCH, uid.Uid, home, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, dockerImage),
 		},
 		{
@@ -119,7 +118,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/home/user -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform %s/%s --user %s -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, runtime.GOOS, runtime.GOARCH, uid.Uid, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, dockerImage),
 		},
 	}

--- a/internal/command/docker_test.go
+++ b/internal/command/docker_test.go
@@ -27,6 +27,7 @@ func TestCmdEngineDocker(t *testing.T) {
 	log.Println(expectedCmd)
 
 	uid, _ := user.Current()
+	home := os.Getenv("HOME")
 
 	workDir := filepath.Join(os.TempDir(), "fyne-cross-test", "app")
 	cacheDir := filepath.Join(os.TempDir(), "fyne-cross-test", "cache")
@@ -65,7 +66,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -u %s:%s --entrypoint fixuid -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s -q command arg", expectedCmd, workDir, uid.Uid, uid.Gid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, uid.Uid, home, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, dockerImage),
 		},
 		{
@@ -83,7 +84,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform linux/amd64 -u %s:%s --entrypoint fixuid -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s -q command arg", expectedCmd, customWorkDir, workDir, uid.Uid, uid.Gid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, uid.Uid, home, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w %s -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, customWorkDir, workDir, dockerImage),
 		},
 		{
@@ -100,7 +101,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform linux/amd64 -u %s:%s --entrypoint fixuid -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s -q command arg", expectedCmd, workDir, cacheDir, uid.Uid, uid.Gid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, uid.Uid, home, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z -v %s:/go:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build %s command arg", expectedCmd, workDir, cacheDir, dockerImage),
 		},
 		{
@@ -118,7 +119,7 @@ func TestCmdEngineDocker(t *testing.T) {
 				opts:    options{},
 				cmdArgs: []string{"command", "arg"},
 			},
-			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -u %s:%s --entrypoint fixuid -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s -q command arg", expectedCmd, workDir, uid.Uid, uid.Gid, dockerImage),
+			want:        fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 --user %s -e HOME=/home/user -v %s/.cache/zig:/home/user/.cache/zig -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, uid.Uid, home, dockerImage),
 			wantWindows: fmt.Sprintf("%s run --rm -t -w /app -v %s:/app:z --platform linux/amd64 -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOPROXY=proxy.example.com %s command arg", expectedCmd, workDir, dockerImage),
 		},
 	}

--- a/internal/command/docker_test.go
+++ b/internal/command/docker_test.go
@@ -33,7 +33,6 @@ func TestCmdEngineDocker(t *testing.T) {
 		mountFlag = ""
 	}
 
-
 	workDir := filepath.Join(os.TempDir(), "fyne-cross-test", "app")
 	cacheDir := filepath.Join(os.TempDir(), "fyne-cross-test", "cache")
 	customWorkDir := filepath.Join(os.TempDir(), "fyne-cross-test", "custom")

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -55,6 +55,8 @@ type CommonFlags struct {
 	NoResultDownload bool
 	// NoStripDebug if true will not strip debug information from binaries
 	NoStripDebug bool
+	// NoNetwork if true will not setup network inside the container
+	NoNetwork bool
 	// Name represents the application name
 	Name string
 	// Release represents if the package should be prepared for release (disable debug etc)
@@ -133,6 +135,7 @@ func newCommonFlags() (*CommonFlags, error) {
 	flagSet.BoolVar(&flags.Debug, "debug", false, "Debug mode")
 	flagSet.BoolVar(&flags.Pull, "pull", false, "Attempt to pull a newer version of the docker image")
 	flagSet.StringVar(&flags.DockerRegistry, "docker-registry", "docker.io", "The docker registry to be used instead of dockerhub (only used with defualt docker images)")
+	flagSet.BoolVar(&flags.NoNetwork, "no-network", false, "If set, the build will be done without network access")
 	return flags, nil
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
fixuid was sub-optimal for builds and spent a considerable amount of time doing unnecessary work.
This PR removes fixuid and instead sets HOME properly so that the zig compiler is able to write its cache files.
Also, if the host user's HOME is set (the general case), the host zip cache directory is mapped to the container for persistent cache between targets and subsequent builds.

Tests updated to work although tests were and continue to be broken on darwin

Fixes #181

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

