### PR TITLE
Add ability to disable network in the container while building.

### DIFF
--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -60,6 +60,7 @@ type Context struct {
 	Pull             bool   // Pull if true attempts to pull a newer version of the docker image
 	NoProjectUpload  bool   // NoProjectUpload if true, the build will be done with the artifact already stored on S3
 	NoResultDownload bool   // NoResultDownload if true, the result of the build will be left on S3 and not downloaded locally
+	NoNetwork        bool   // NoNetwork if true, the build will be done without network access
 
 	//Build context
 	BuildMode string // The -buildmode argument to pass to go build
@@ -142,6 +143,7 @@ func makeDefaultContext(flags *CommonFlags, args []string) (Context, error) {
 		Name:             flags.Name,
 		StripDebug:       !flags.NoStripDebug,
 		Debug:            flags.Debug,
+		NoNetwork:        flags.NoNetwork,
 		Volume:           vol,
 		Pull:             flags.Pull,
 		Release:          flags.Release,

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -27,6 +27,7 @@ type localContainerEngine struct {
 
 	pull         bool
 	cacheEnabled bool
+	noNetwork    bool
 }
 
 func newLocalContainerEngine(context Context) (containerEngine, error) {
@@ -39,6 +40,7 @@ func newLocalContainerEngine(context Context) (containerEngine, error) {
 		engine:       &context.Engine,
 		pull:         context.Pull,
 		cacheEnabled: context.CacheEnabled,
+		noNetwork:    context.NoNetwork,
 	}, nil
 }
 
@@ -150,6 +152,10 @@ func (i *localContainerImage) cmd(vol volume.Volume, opts options, cmdArgs []str
 		"-e", "CGO_ENABLED=1", // enable CGO
 		"-e", fmt.Sprintf("GOCACHE=%s", vol.GoCacheDirContainer()), // mount GOCACHE to reuse cache between builds
 	)
+
+	if i.runner.noNetwork {
+		args = append(args, "--network=none")
+	}
 
 	// add custom env variables
 	args = AppendEnv(args, i.runner.env, i.env["GOOS"] != freebsdOS)

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -55,6 +55,8 @@ type CommonFlags struct {
 	NoResultDownload bool
 	// NoStripDebug if true will not strip debug information from binaries
 	NoStripDebug bool
+	// NoNetwork if true will not setup network inside the container
+	NoNetwork bool
 	// Name represents the application name
 	Name string
 	// Release represents if the package should be prepared for release (disable debug etc)
@@ -133,6 +135,7 @@ func newCommonFlags() (*CommonFlags, error) {
 	flagSet.BoolVar(&flags.Debug, "debug", false, "Debug mode")
 	flagSet.BoolVar(&flags.Pull, "pull", false, "Attempt to pull a newer version of the docker image")
 	flagSet.StringVar(&flags.DockerRegistry, "docker-registry", "docker.io", "The docker registry to be used instead of dockerhub (only used with defualt docker images)")
+	flagSet.BoolVar(&flags.NoNetwork, "no-network", false, "If set, the build will be done without network access")
 	return flags, nil
 }
 


### PR DESCRIPTION
### Description:
This can only be used with vendored directory. It does provide two main benefit. First not setting up network, means that the build will not be able to get any data from the outside. It give you that guarantee that only the source code that is in your vendor directory was used. Second it is faster to setup a container without network.

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Public APIs match existing style.
