### PR TITLE
Bugs/support go1.20 darwin

### DIFF
--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/log"
 	"github.com/fyne-io/fyne-cross/internal/volume"
@@ -249,6 +250,12 @@ func (cmd *darwin) setupContainerImages(flags *darwinFlags, args []string) error
 					return errors.New("macOSX SDK path does not exists")
 				}
 				image.SetMount("sdk", flags.MacOSXSDKPath, "/sdk")
+			}
+		} else {
+			if v, ok := ctx.Env["GOFLAGS"]; ok {
+				ctx.Env["GOFLAGS"] = strings.TrimSpace(v + " -ldflags=-extldflags -ldflags=-lresolv")
+			} else {
+				ctx.Env["GOFLAGS"] = "-ldflags=-extldflags -ldflags=-lresolv"
 			}
 		}
 

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -234,7 +234,7 @@ func (cmd *darwin) setupContainerImages(flags *darwinFlags, args []string) error
 		zigCXX := fmt.Sprintf("zig c++ -v -target %s -isysroot /sdk -iwithsysroot /usr/include -iframeworkwithsysroot /System/Library/Frameworks", zigTarget)
 		image.SetEnv("CC", zigCC)
 		image.SetEnv("CXX", zigCXX)
-		image.SetEnv("CGO_LDFLAGS", "--sysroot /sdk -F/System/Library/Frameworks -L/usr/lib")
+		image.SetEnv("CGO_LDFLAGS", "--sysroot /sdk -F/System/Library/Frameworks -L/usr/lib -lresolv")
 		image.SetEnv("GOOS", "darwin")
 
 		if !cmd.localBuild {

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -67,9 +67,8 @@ func (cmd *darwin) Parse(args []string) error {
 	// Add flags to use only on darwin host
 	if runtime.GOOS == darwinOS {
 		flagSet.BoolVar(&cmd.localBuild, "local", true, "If set uses the fyne CLI tool installed on the host in place of the docker images")
-	} else {
-		flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK (setting it to 'bundled' indicates that the sdk is expected to be in the container) [required]")
 	}
+	flagSet.StringVar(&flags.MacOSXSDKPath, "macosx-sdk-path", "unset", "Path to macOS SDK (setting it to 'bundled' indicates that the sdk is expected to be in the container) [required]")
 
 	// flags used only in release mode
 	flagSet.StringVar(&flags.Category, "category", "", "The category of the app for store listing")

--- a/internal/command/ios.go
+++ b/internal/command/ios.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/fyne-io/fyne-cross/internal/log"
 	"github.com/fyne-io/fyne-cross/internal/volume"
@@ -156,6 +157,12 @@ func (cmd *iOS) setupContainerImages(flags *iosFlags, args []string) error {
 	runner, err := newContainerEngine(ctx)
 	if err != nil {
 		return err
+	}
+
+	if v, ok := ctx.Env["GOFLAGS"]; ok {
+		ctx.Env["GOFLAGS"] = strings.TrimSpace(v + " -ldflags=-extldflags -ldflags=-lresolv")
+	} else {
+		ctx.Env["GOFLAGS"] = "-ldflags=-extldflags -ldflags=-lresolv"
 	}
 
 	cmd.Images = append(cmd.Images, runner.createContainerImage("", iosOS, overrideDockerImage(flags.CommonFlags, iosImage)))

--- a/internal/command/kubernetes.go
+++ b/internal/command/kubernetes.go
@@ -151,6 +151,7 @@ func (i *kubernetesContainerImage) close() error {
 }
 
 func (i *kubernetesContainerImage) Run(vol volume.Volume, opts options, cmdArgs []string) error {
+	log.Debug(opts.WorkDir, cmdArgs)
 	return i.pod.Run(opts.WorkDir, cmdArgs)
 }
 
@@ -227,6 +228,8 @@ func (i *kubernetesContainerImage) Prepare() error {
 
 	name := fmt.Sprintf("fyne-cross-%s-%x", i.ID(), unique)
 	namespace := i.runner.namespace
+
+	log.Debug("Creating pod", name, namespace, i.DockerImage, mount, env)
 
 	i.pod, err = i.runner.client.NewPod(context.Background(),
 		name, i.DockerImage, namespace,


### PR DESCRIPTION
### Description:
So apparently with go 1.20, we need to add `-lresolv` manually for some reason on darwin when any dependencies use the net package :-(

See https://github.com/golang/go/issues/58416 and https://github.com/golang/go/issues/58159

I know we could rely on the user having to set it manually, but I think that having it by default will help fyne-cross user and reduce the potential bug report. We could also detect if a project use the net package and add it only if needed, but I don't think it is a big deal to always add it.