### PR TITLE
Remove unecessary quote

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -191,7 +191,7 @@ func fyneCommand(binary, command, icon string, ctx Context, image containerImage
 	// add tags to command, if any
 	tags := image.Tags()
 	if len(tags) > 0 {
-		args = append(args, "-tags", fmt.Sprintf("%s", strings.Join(tags, ",")))
+		args = append(args, "-tags", strings.Join(tags, ","))
 	}
 
 	if ctx.Metadata != nil {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -191,7 +191,7 @@ func fyneCommand(binary, command, icon string, ctx Context, image containerImage
 	// add tags to command, if any
 	tags := image.Tags()
 	if len(tags) > 0 {
-		args = append(args, "-tags", fmt.Sprintf("%q", strings.Join(tags, ",")))
+		args = append(args, "-tags", fmt.Sprintf("%s", strings.Join(tags, ",")))
 	}
 
 	if ctx.Metadata != nil {


### PR DESCRIPTION
### Description:
For historical reason go tags can't have space and the quote escaping was actually done by the shell before. Now, as we call fyne directly, we should not quote tags as once passed to go, it breaks things.

Fixes #195 

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.