### PR TITLE
Bugs/ssh agent darwin

### DIFF
--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -139,7 +139,12 @@ func (i *localContainerImage) cmd(vol volume.Volume, opts options, cmdArgs []str
 
 	// detect ssh-agent socket for private repositories access
 	if sshAuthSock := os.Getenv("SSH_AUTH_SOCK"); sshAuthSock != "" {
-		if realSshAuthSock, err := filepath.EvalSymlinks(sshAuthSock); err == nil {
+		if runtime.GOOS == "darwin" {
+			// on macOS, the SSH_AUTH_SOCK is not available in the container directly,
+			// but instead we need to the magic path "/run/host-services/ssh-auth.sock"
+			args = append(args, "-v", "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock")
+			args = append(args, "-e", "SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock")
+		} else if realSshAuthSock, err := filepath.EvalSymlinks(sshAuthSock); err == nil {
 			args = append(args, "-v", fmt.Sprintf("%s:/tmp/ssh-agent", realSshAuthSock))
 			args = append(args, "-e", "SSH_AUTH_SOCK=/tmp/ssh-agent")
 		}


### PR DESCRIPTION
### Description:
On MacOS, Linux is running in a VM that then start the container. This means the container does not see exactly the host path, but instead the VM path. For ssh-agent, Docker create a magic path /run/host-services/ssh-auth.sock instead.

Fixes #201

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
