### PR TITLE
Add "key-name" argument to release Android package

### DIFF
--- a/internal/command/android.go
+++ b/internal/command/android.go
@@ -63,6 +63,7 @@ func (cmd *android) Parse(args []string) error {
 	flagSet.StringVar(&flags.Keystore, "keystore", "", "The location of .keystore file containing signing information")
 	flagSet.StringVar(&flags.KeystorePass, "keystore-pass", "", "Password for the .keystore file")
 	flagSet.StringVar(&flags.KeyPass, "key-pass", "", "Password for the signer's private key, which is needed if the private key is password-protected")
+	flagSet.StringVar(&flags.KeyName, "key-name", "", "Name of the key to use for signing")
 
 	flagSet.Usage = cmd.Usage
 	flagSet.Parse(args)
@@ -147,6 +148,7 @@ type androidFlags struct {
 	Keystore     string //Keystore represents the location of .keystore file containing signing information
 	KeystorePass string //Password for the .keystore file
 	KeyPass      string //Password for the signer's private key, which is needed if the private key is password-protected
+	KeyName      string //Name of the key to use for signing
 
 	// TargetArch represents a list of target architecture to build on separated by comma
 	TargetArch *targetArchFlag
@@ -196,6 +198,7 @@ func (cmd *android) setupContainerImages(flags *androidFlags, args []string) err
 		cmd.defaultContext.Keystore = volume.JoinPathContainer(cmd.defaultContext.Volume.WorkDirContainer(), flags.Keystore)
 		cmd.defaultContext.KeystorePass = flags.KeystorePass
 		cmd.defaultContext.KeyPass = flags.KeyPass
+		cmd.defaultContext.KeyName = flags.KeyName
 
 		cmd.Images = append(cmd.Images, image)
 	}

--- a/internal/command/container.go
+++ b/internal/command/container.go
@@ -247,6 +247,9 @@ func fyneRelease(ctx Context, image containerImage) error {
 		if ctx.KeyPass != "" {
 			args = append(args, "-keyPass", ctx.KeyPass)
 		}
+		if ctx.KeyName != "" {
+			args = append(args, "-keyName", ctx.KeyName)
+		}
 	case iosOS:
 		if ctx.Certificate != "" {
 			args = append(args, "-certificate", ctx.Certificate)

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -72,6 +72,7 @@ type Context struct {
 	Keystore     string //Keystore represents the location of .keystore file containing signing information [Android]
 	KeystorePass string //KeystorePass represents the password for the .keystore file [Android]
 	KeyPass      string //KeyPass represents the assword for the signer's private key, which is needed if the private key is password-protected [Android]
+	KeyName      string //KeyName represents the name of the key to sign the build [Android]
 	Password     string //Password represents the password for the certificate used to sign the build [Windows]
 	Profile      string //Profile represents the name of the provisioning profile for this release build [iOS]
 }


### PR DESCRIPTION
The keystore need to know the key name to use.

### Description:
<!-- A summary of the change included and which issue it addresses.
To release android 'aab' package, the `release` command needs `-key-name` to select the key from the keystore.

Note: I use, at this time, a custom image where I installed `bundletool`. I will do a PR for this un the fyne-cross-images.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

