### PR TITLE
Turn on dependabot.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
This is to turn on dependabot. Currently targetting develop as I will do one PR to get everything once all the last PR are merged here and we can push a new release. Should be shortly.