### PR TITLE
Enable-macos-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - develop
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: "CI"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -88,10 +93,10 @@ jobs:
           - os: freebsd
           - os: android
             args: -app-id calc.sha${{ github.sha }}
-          ## Not shared darwin image is available at the moment
-          # - os: darwin
-          #  args: -app-id calc.sha${{ github.sha }}
-          #  host: macos-latest
+          - os: darwin
+            args: -app-id calc.sha${{ github.sha }}
+          # Only macos-13 is supported as macos-14 is running in a VM on Mac M1 which are incompatible with docker/podman
+            host: macos-13
           - os: web
           
           ## Currently not easily supported from GitHub actions.
@@ -137,13 +142,10 @@ jobs:
           go install fyne.io/fyne/v2/cmd/fyne@latest ||
           go get fyne.io/fyne/v2/cmd/fyne@latest
 
-      - name: Install Podman
+      - name: Install Docker
         if: ${{ runner.os == 'macos' }}
-        run: |
-          brew install podman
-          podman machine init
-          podman machine start
-            
+        uses: douglascamata/setup-docker-macos-action@v1-alpha
+    
       - name: Build
         working-directory: calculator
         run: |
@@ -170,11 +172,10 @@ jobs:
           - os: freebsd
           - os: android
             args: -app-id calc.sha${{ github.sha }}
-          ## Not shared darwin image is available at the moment
-          # - os: darwin
-          #  args: -app-id calc.sha${{ github.sha }}
-          #  host: macos-latest
-          # - os: web
+          - os: darwin
+            args: -app-id calc.sha${{ github.sha }}
+          # Only macos-13 is supported as macos-14 is running in a VM on Mac M1 which are incompatible with docker/podman
+            host: macos-13
           
           ## Currently not easily supported from GitHub actions.
           ## https://github.com/fyne-io/fyne-cross/pull/104#issuecomment-1099494308
@@ -219,13 +220,10 @@ jobs:
           go install fyne.io/fyne/v2/cmd/fyne@latest ||
           go get fyne.io/fyne/v2/cmd/fyne@latest
 
-      - name: Install Podman
+      - name: Install Docker
         if: ${{ runner.os == 'macos' }}
-        run: |
-          brew install podman
-          podman machine init
-          podman machine start
-
+        uses: douglascamata/setup-docker-macos-action@v1-alpha
+ 
       - name: Build
         working-directory: terminal
         run: |


### PR DESCRIPTION
### Description:
Turn back on CI for MacOS and Web target.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
