### PR TITLE
Ldflags where only needed with older version of zig which we have updated since then.

### DIFF
--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -187,8 +187,6 @@ func (cmd *darwin) setupContainerImages(flags *darwinFlags, args []string) error
 		return fmt.Errorf("could not make command context for %s OS: %s", darwinOS, err)
 	}
 
-	flags.Ldflags += " -s -w"
-
 	ctx, err := makeDefaultContext(flags.CommonFlags, args)
 	if err != nil {
 		return err
@@ -200,7 +198,7 @@ func (cmd *darwin) setupContainerImages(flags *darwinFlags, args []string) error
 
 	ctx.Category = flags.Category
 
-	// Following settings are needed to cross compile with zig 0.9.1
+	// Following settings are needed to cross compile with zig
 	ctx.BuildMode = "pie"
 
 	cmd.defaultContext = ctx


### PR DESCRIPTION
### Description:
Change on how we handle ldflags to pass them via GOFLAGS broke building for Darwin when on Linux and Windows. The code is actually not useful anymore as we have moved to updated zig since that was added. Simple solution remove the code.

Fixes #232

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [x] Tests all pass.
