### PR TITLE
Performance improvement by avoiding running commands in docker

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -97,20 +97,18 @@ Use "fyne-cross <command> -help" for more information about a command.
 func cleanTargetDirs(ctx Context, image containerImage) error {
 
 	dirs := map[string]string{
-		"bin":  volume.JoinPathContainer(ctx.BinDirContainer(), image.ID()),
-		"dist": volume.JoinPathContainer(ctx.DistDirContainer(), image.ID()),
-		"temp": volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID()),
+		"bin":  volume.JoinPathHost(ctx.Volume.BinDirHost(), image.ID()),
+		"dist": volume.JoinPathHost(ctx.Volume.DistDirHost(), image.ID()),
+		"temp": volume.JoinPathHost(ctx.Volume.TmpDirHost(), image.ID()),
 	}
 
 	log.Infof("[i] Cleaning target directories...")
 	for k, v := range dirs {
-		err := image.Run(ctx.Volume, options{}, []string{"rm", "-rf", v})
-		if err != nil {
+		if err := os.RemoveAll(v); err != nil {
 			return fmt.Errorf("could not clean the %q dir %s: %v", k, v, err)
 		}
 
-		err = image.Run(ctx.Volume, options{}, []string{"mkdir", "-p", v})
-		if err != nil {
+		if err := os.MkdirAll(v, os.ModePerm); err != nil {
 			return fmt.Errorf("could not create the %q dir %s: %v", k, v, err)
 		}
 
@@ -142,10 +140,12 @@ func prepareIcon(ctx Context, image containerImage) error {
 		}
 	}
 
-	err := image.Run(ctx.Volume, options{}, []string{"cp", volume.JoinPathContainer(ctx.WorkDirContainer(), ctx.Icon), volume.JoinPathContainer(ctx.TmpDirContainer(), image.ID(), icon.Default)})
-	if err != nil {
-		return fmt.Errorf("could not copy the icon to temp folder: %v", err)
+	if data, err := os.ReadFile(volume.JoinPathHost(ctx.Volume.WorkDirHost(), ctx.Icon)); err != nil {
+		return fmt.Errorf("could not read in icon %s: %w", ctx.Icon, err)
+	} else if err := os.WriteFile(volume.JoinPathHost(ctx.TmpDirHost(), image.ID(), icon.Default), data, 0644); err != nil {
+		return fmt.Errorf("could not copy icon %s to tmp folder: %w", ctx.Icon, err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
I noticed that fyne-cross running on my gitlab CI was taking a very long time to clean directories that don't even exist.  I found that because these cleans are run using docker - it takes a while just to spin up the container to run them.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
