### PR TITLE
Revert "Bump github.com/klauspost/compress from 1.13.4 to 1.17.9"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9
 	github.com/aws/aws-sdk-go v1.51.13
-	github.com/klauspost/compress v1.17.9
+	github.com/klauspost/compress v1.13.4
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
@@ -62,8 +63,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.13.4 h1:0zhec2I8zGnjWcKyLl6i3gPqKANCCn5e9xmviEEeX6s=
+github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=

--- a/internal/cloud/s3.go
+++ b/internal/cloud/s3.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -104,7 +103,7 @@ func (a *AWSSession) UploadFile(localFile string, s3FilePath string) error {
 }
 
 func (a *AWSSession) UploadCompressedDirectory(localDirectoy string, s3FilePath string) error {
-	file, err := ioutil.TempFile("", "fyne-cross-s3")
+	file, err := os.CreateTemp("", "fyne-cross-s3")
 	if err != nil {
 		return err
 	}
@@ -255,7 +254,7 @@ func (a *AWSSession) DownloadFile(s3FilePath string, localFile string) error {
 }
 
 func (a *AWSSession) DownloadCompressedDirectory(s3FilePath string, localRootDirectory string) error {
-	file, err := ioutil.TempFile("", "fyne-cross-s3")
+	file, err := os.CreateTemp("", "fyne-cross-s3")
 	if err != nil {
 		return err
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -134,7 +133,7 @@ func prepareIcon(ctx Context, image containerImage) error {
 			}
 
 			log.Infof("[!] Default icon not found at %q", ctx.Icon)
-			err = ioutil.WriteFile(volume.JoinPathHost(ctx.WorkDirHost(), ctx.Icon), icon.FyneLogo, 0644)
+			err = os.WriteFile(volume.JoinPathHost(ctx.WorkDirHost(), ctx.Icon), icon.FyneLogo, 0644)
 			if err != nil {
 				return fmt.Errorf("could not create the temporary icon: %s", err)
 			}

--- a/internal/command/darwin_sdk_extract.go
+++ b/internal/command/darwin_sdk_extract.go
@@ -3,7 +3,6 @@ package command
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func (cmd *DarwinSDKExtract) Run() error {
 	}
 
 	// mount the fyne-cross volume
-	workDir, err := ioutil.TempDir("", cmd.Name())
+	workDir, err := os.MkdirTemp("", cmd.Name())
 	if err != nil {
 		return err
 	}

--- a/internal/command/kubernetes.go
+++ b/internal/command/kubernetes.go
@@ -151,7 +151,7 @@ func (i *kubernetesContainerImage) close() error {
 }
 
 func (i *kubernetesContainerImage) Run(vol volume.Volume, opts options, cmdArgs []string) error {
-	return i.pod.Run(opts.WorkDir, cmdArgs)
+	return i.pod.Run(context.Background(), opts.WorkDir, cmdArgs)
 }
 
 func AddAWSParameters(aws *cloud.AWSSession, command string, s ...string) []string {

--- a/internal/metadata/load.go
+++ b/internal/metadata/load.go
@@ -2,7 +2,6 @@ package metadata
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -12,7 +11,7 @@ import (
 // Load attempts to read a FyneApp metadata from the provided reader.
 // If this cannot be done an error will be returned.
 func Load(r io.Reader) (*FyneApp, error) {
-	str, err := ioutil.ReadAll(r)
+	str, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/volume/volume.go
+++ b/internal/volume/volume.go
@@ -7,7 +7,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -31,11 +30,11 @@ const (
 
 // Copy copies a resource from src to dest
 func Copy(src string, dst string) error {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dst, data, 0644)
+	return os.WriteFile(dst, data, 0644)
 }
 
 // DefaultCacheDirHost returns the default cache dir on the host


### PR DESCRIPTION
This reverts commit ced8fa91138c6018da42b7790cec73e8dd3e8de0.

compress 1.17.9 does not compile with go 1.19

### Checklist:
- [x] Tests all pass.
